### PR TITLE
fixes panic when terminal was resized

### DIFF
--- a/examples/block.rs
+++ b/examples/block.rs
@@ -8,7 +8,7 @@ use termion::input::TermRead;
 use tui::Terminal;
 use tui::backend::TermionBackend;
 use tui::widgets::{Widget, Block, border};
-use tui::layout::{Group, Direction, Size};
+use tui::layout::{Group, Direction, Size, Rect};
 use tui::style::{Style, Color, Modifier};
 
 fn main() {
@@ -16,9 +16,16 @@ fn main() {
     let stdin = io::stdin();
     terminal.clear().unwrap();
     terminal.hide_cursor().unwrap();
-    draw(&mut terminal);
+
+    let mut term_size = terminal.size().unwrap();
+    draw(&mut terminal, &term_size);
     for c in stdin.keys() {
-        draw(&mut terminal);
+        let size = terminal.size().unwrap();
+        if term_size != size {
+            terminal.resize(size).unwrap();
+            term_size = size;
+        }
+        draw(&mut terminal, &term_size);
         let evt = c.unwrap();
         if evt == event::Key::Char('q') {
             break;
@@ -27,9 +34,7 @@ fn main() {
     terminal.show_cursor().unwrap();
 }
 
-fn draw(t: &mut Terminal<TermionBackend>) {
-
-    let size = t.size().unwrap();
+fn draw(t: &mut Terminal<TermionBackend>, size: &Rect) {
 
     // Wrapping block for a group
     // Just draw the block and the group on the same area and build the group

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -24,6 +24,8 @@ struct App {
     playground: Rect,
     vx: u16,
     vy: u16,
+    dir_x: bool,
+    dir_y: bool,
 }
 
 
@@ -33,23 +35,36 @@ impl App {
             size: Default::default(),
             x: 0.0,
             y: 0.0,
-            ball: Rect::new(20, 20, 10, 10),
+            ball: Rect::new(10, 30, 10, 10),
             playground: Rect::new(10, 10, 100, 100),
             vx: 1,
             vy: 1,
+            dir_x: true,
+            dir_y: true,
         }
     }
 
     fn advance(&mut self) {
         if self.ball.left() < self.playground.left() ||
-           self.ball.right() > self.playground.right() {
-            self.vx = !self.vx;
-        } else if self.ball.top() < self.playground.top() ||
-                  self.ball.bottom() > self.playground.bottom() {
-            self.vy = !self.vy;
+            self.ball.right() > self.playground.right() {
+               self.dir_x = !self.dir_x;
+           }
+        if self.ball.top() < self.playground.top() ||
+            self.ball.bottom() > self.playground.bottom() {
+                self.dir_y = !self.dir_y;
+            }
+
+        if self.dir_x {
+            self.ball.x += self.vx;
+        } else {
+            self.ball.x -= self.vx;
         }
-        self.ball.x += self.vx;
-        self.ball.y += self.vy;
+
+        if self.dir_y {
+            self.ball.y += self.vy;
+        } else {
+            self.ball.y -= self.vy
+        }
     }
 }
 
@@ -94,11 +109,16 @@ fn main() {
     // First draw call
     terminal.clear().unwrap();
     terminal.hide_cursor().unwrap();
-    let size = terminal.size().unwrap();
-    app.size = size;
+    app.size = terminal.size().unwrap();
     draw(&mut terminal, &app);
 
     loop {
+        let size = terminal.size().unwrap();
+        if size != app.size {
+            terminal.resize(size).unwrap();
+            app.size = size;
+        }
+
         let evt = rx.recv().unwrap();
         match evt {
             Event::Input(input) => {
@@ -125,11 +145,6 @@ fn main() {
             Event::Tick => {
                 app.advance();
             }
-        }
-        let size = terminal.size().unwrap();
-        if size != app.size {
-            app.size = size;
-            terminal.resize(size).unwrap();
         }
         draw(&mut terminal, &app);
     }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -12,10 +12,11 @@ use termion::input::TermRead;
 use tui::Terminal;
 use tui::backend::TermionBackend;
 use tui::widgets::{Widget, Block, border, SelectableList, List};
-use tui::layout::{Group, Direction, Size};
+use tui::layout::{Group, Direction, Size, Rect};
 use tui::style::{Style, Color, Modifier};
 
 struct App<'a> {
+    size: Rect,
     items: Vec<&'a str>,
     selected: usize,
     events: Vec<(&'a str, &'a str)>,
@@ -28,6 +29,7 @@ struct App<'a> {
 impl<'a> App<'a> {
     fn new() -> App<'a> {
         App {
+            size: Rect::default(),
             items: vec!["Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8",
                         "Item9", "Item10", "Item11", "Item12", "Item13", "Item14", "Item15",
                         "Item16", "Item17", "Item18", "Item19", "Item20", "Item21", "Item22",
@@ -113,9 +115,16 @@ fn main() {
     // First draw call
     terminal.clear().unwrap();
     terminal.hide_cursor().unwrap();
+    app.size = terminal.size().unwrap();
     draw(&mut terminal, &app);
 
     loop {
+        let size = terminal.size().unwrap();
+        if size != app.size {
+            terminal.resize(size).unwrap();
+            app.size = size;
+        }
+
         let evt = rx.recv().unwrap();
         match evt {
             Event::Input(input) => {
@@ -151,12 +160,10 @@ fn main() {
 
 fn draw(t: &mut Terminal<TermionBackend>, app: &App) {
 
-    let size = t.size().unwrap();
-
     Group::default()
         .direction(Direction::Horizontal)
         .sizes(&[Size::Percent(50), Size::Percent(50)])
-        .render(t, &size, |t, chunks| {
+        .render(t, &app.size, |t, chunks| {
             SelectableList::default()
                 .block(Block::default()
                     .borders(border::ALL)

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -8,7 +8,7 @@ use termion::input::TermRead;
 use tui::Terminal;
 use tui::backend::TermionBackend;
 use tui::widgets::{Widget, Block, Paragraph};
-use tui::layout::{Group, Direction, Size};
+use tui::layout::{Group, Direction, Size, Rect};
 use tui::style::{Style, Color};
 
 fn main() {
@@ -16,9 +16,18 @@ fn main() {
     let stdin = io::stdin();
     terminal.clear().unwrap();
     terminal.hide_cursor().unwrap();
-    draw(&mut terminal);
+
+    let mut term_size = terminal.size().unwrap();
+    draw(&mut terminal, &term_size);
+
     for c in stdin.keys() {
-        draw(&mut terminal);
+        let size = terminal.size().unwrap();
+        if size != term_size {
+            terminal.resize(size).unwrap();
+            term_size = size;
+        }
+
+        draw(&mut terminal, &term_size);
         let evt = c.unwrap();
         if evt == event::Key::Char('q') {
             break;
@@ -27,9 +36,7 @@ fn main() {
     terminal.show_cursor().unwrap();
 }
 
-fn draw(t: &mut Terminal<TermionBackend>) {
-
-    let size = t.size().unwrap();
+fn draw(t: &mut Terminal<TermionBackend>, size: &Rect) {
 
     Block::default()
         .style(Style::default().bg(Color::White))

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -9,10 +9,11 @@ use termion::input::TermRead;
 use tui::Terminal;
 use tui::backend::TermionBackend;
 use tui::widgets::{Widget, Block, border, Table};
-use tui::layout::{Group, Direction, Size};
+use tui::layout::{Group, Direction, Size, Rect};
 use tui::style::{Style, Color, Modifier};
 
 struct App<'a> {
+    size: Rect,
     items: Vec<Vec<&'a str>>,
     selected: usize,
 }
@@ -20,6 +21,7 @@ struct App<'a> {
 impl<'a> App<'a> {
     fn new() -> App<'a> {
         App {
+            size: Rect::default(),
             items: vec![vec!["Row12", "Row12", "Row13"],
                         vec!["Row21", "Row22", "Row23"],
                         vec!["Row31", "Row32", "Row33"],
@@ -43,11 +45,18 @@ fn main() {
     // First draw call
     terminal.clear().unwrap();
     terminal.hide_cursor().unwrap();
+    app.size = terminal.size().unwrap();
     draw(&mut terminal, &app);
 
     // Input
     let stdin = io::stdin();
     for c in stdin.keys() {
+        let size = terminal.size().unwrap();
+        if size != app.size {
+            terminal.resize(size).unwrap();
+            app.size = size;
+        }
+
         let evt = c.unwrap();
         match evt {
             event::Key::Char('q') => {
@@ -76,13 +85,11 @@ fn main() {
 
 fn draw(t: &mut Terminal<TermionBackend>, app: &App) {
 
-    let size = t.size().unwrap();
-
     Group::default()
         .direction(Direction::Horizontal)
         .sizes(&[Size::Percent(100)])
         .margin(5)
-        .render(t, &size, |t, chunks| {
+        .render(t, &app.size, |t, chunks| {
             let selected_style = Style::default().fg(Color::Yellow).modifier(Modifier::Bold);
             let normal_style = Style::default().fg(Color::White);
             Table::default()


### PR DESCRIPTION
Some examples panicked when the terminal was resized. The canvas example also panicked when the *ball* hit the border of the canvas.