### PR TITLE
add note to readme about running/quitting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ The library comes with the following list of widgets:
   * [Canvas (with line, point cloud, map)](examples/canvas.rs)
   * [Tabs](examples/tabs.rs)
 
-Click on each item to get an example.
+Click on each item to see the source of the example. Run the examples with with 
+cargo (e.g. to run the demo `cargo run --example demo`), and quit by pressing `q`.
 
 ### Demo
 


### PR DESCRIPTION
This is a small change, but it was a bit confusing for me when I was evaluating if this repository could do what I want. I did not realize cargo could run examples until now, and I also couldn't figure out how to quit the example while it was running (I was trying things like Ctrl-C). 