### PR TITLE
Text alignment option for paragraph widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = ["termion"]
 [dependencies]
 bitflags = "1.0.1"
 cassowary = "0.3.0"
+itertools = "0.7.8"
 log = "0.4.1"
 unicode-segmentation = "1.2.0"
 unicode-width = "0.1.4"

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -8,7 +8,7 @@ use termion::input::TermRead;
 use tui::Terminal;
 use tui::backend::MouseBackend;
 use tui::layout::{Direction, Group, Rect, Size};
-use tui::style::{Color, Style};
+use tui::style::{Alignment, Color, Style};
 use tui::widgets::{Block, Paragraph, Widget};
 
 fn main() {
@@ -44,13 +44,46 @@ fn draw(t: &mut Terminal<MouseBackend>, size: &Rect) {
     Group::default()
         .direction(Direction::Vertical)
         .margin(5)
-        .sizes(&[Size::Percent(100)])
+        .sizes(&[Size::Percent(30), Size::Percent(30), Size::Percent(30)])
         .render(t, size, |t, chunks| {
             Group::default()
                 .direction(Direction::Horizontal)
                 .sizes(&[Size::Percent(100)])
                 .render(t, &chunks[0], |t, chunks| {
                     Paragraph::default()
+                        .alignment(Alignment::Left)
+                        .text(
+                            "This is a line\n{fg=red This is a line}\n{bg=red This is a \
+                             line}\n{mod=italic This is a line}\n{mod=bold This is a \
+                             line}\n{mod=crossed_out This is a line}\n{mod=invert This is a \
+                             line}\n{mod=underline This is a \
+                             line}\n{bg=green;fg=yellow;mod=italic This is a line}\n",
+                        )
+                        .render(t, &chunks[0]);
+                });
+            Group::default()
+                .direction(Direction::Horizontal)
+                .sizes(&[Size::Percent(100)])
+                .render(t, &chunks[1], |t, chunks| {
+                    Paragraph::default()
+                        .alignment(Alignment::Center)
+                        .wrap(true)
+                        .text(
+                            "This is a line\n{fg=red This is a line}\n{bg=red This is a \
+                             line}\n{mod=italic This is a line}\n{mod=bold This is a \
+                             line}\n{mod=crossed_out This is a line}\n{mod=invert This is a \
+                             line}\n{mod=underline This is a \
+                             line}\n{bg=green;fg=yellow;mod=italic This is a line}\n",
+                        )
+                        .render(t, &chunks[0]);
+                });
+            Group::default()
+                .direction(Direction::Horizontal)
+                .sizes(&[Size::Percent(100)])
+                .render(t, &chunks[2], |t, chunks| {
+                    Paragraph::default()
+                        .alignment(Alignment::Right)
+                        .wrap(true)
                         .text(
                             "This is a line\n{fg=red This is a line}\n{bg=red This is a \
                              line}\n{mod=italic This is a line}\n{mod=bold This is a \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@
 #[macro_use]
 extern crate bitflags;
 extern crate cassowary;
+extern crate itertools;
 #[macro_use]
 extern crate log;
 extern crate unicode_segmentation;

--- a/src/style.rs
+++ b/src/style.rs
@@ -41,6 +41,13 @@ pub enum Modifier {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Alignment {
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     pub fg: Color,
     pub bg: Color,


### PR DESCRIPTION
I needed this functionality for a project I'm working on and thought it made sense to implement it in the widget itself.
The multipeek implementation is taken from itertools to avoid pulling it as a dependency.
Word wrap seems to work.
I have not tested this implementation with fancy unicode characters.

Failed travis is due to formatting errors in other files, I did not touch.