### PR TITLE
fix(widgets): Prevent chart legend from rendering when no dataset has a name

### DIFF
--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -322,6 +322,7 @@ where
             let legend_height = self.datasets.len() as u16 + 2;
             if legend_width < layout.graph_area.width / 3
                 && legend_height < layout.graph_area.height / 3
+                && inner_width > 0
             {
                 layout.legend_area = Some(Rect::new(
                     layout.graph_area.right() - legend_width,


### PR DESCRIPTION
Consider the following code. Notice that the dataset passed in to the chart does not set an explicit `name` property.

```
Chart::default()
    .block(Block::default().title("Plot").borders(Borders::ALL))
    .x_axis(Axis::default()
        .title("X")
        .bounds([0.0, 1.0])
        .labels(&[
                "0",
                "1",
        ]))
    .y_axis(Axis::default()
        .title("Y")
        .bounds([0.0, 1.0])
        .labels(&[
                "0",
                "1",
        ]))
    .datasets(&[Dataset::default()
                .marker(Marker::Braille)
                .style(Style::default().fg(Color::Magenta))
                .data(&vec![(0.0, 0.0), (1.0, 1.0)])
        ])
    .render(t, &chunks[0]);
```

This code causes a chart to render like this:

![before](https://user-images.githubusercontent.com/385684/44314360-4332ac00-a3e6-11e8-964c-250ae7a86823.png)

By checking that the maximum length of a dataset name is above 0, we avoid rendering the legend when there is no dataset name.

After this fix is applied, the above code renders like this:

![after](https://user-images.githubusercontent.com/385684/44314370-665d5b80-a3e6-11e8-97c7-4387ca59a5ff.png)
