### PR TITLE
Make Text accept both borrowed and owned strings

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -439,21 +439,21 @@ fn draw_charts(f: &mut Frame<MouseBackend>, app: &App, area: Rect) {
 
 fn draw_text(f: &mut Frame<MouseBackend>, area: Rect) {
     let text = [
-        Text::Data("This is a paragraph with several lines. You can change style your text the way you want.\n\nFox example: ".into()),
-        Text::StyledData("under".into(), Style::default().fg(Color::Red)),
-        Text::Data(" ".into()),
-        Text::StyledData("the".into(), Style::default().fg(Color::Green)),
-        Text::Data(" ".into()),
-        Text::StyledData("rainbow".into(), Style::default().fg(Color::Blue)),
-        Text::Data(".\nOh and if you didn't ".into()),
-        Text::StyledData("notice".into(), Style::default().modifier(Modifier::Italic)),
-        Text::Data(" you can ".into()),
-        Text::StyledData("automatically".into(), Style::default().modifier(Modifier::Bold)),
-        Text::Data(" ".into()),
-        Text::StyledData("wrap".into(), Style::default().modifier(Modifier::Invert)),
-        Text::Data(" your ".into()),
-        Text::StyledData("text".into(), Style::default().modifier(Modifier::Underline)),
-        Text::Data(".\nOne more thing is that it should display unicode characters: 10€".into())
+        Text::raw("This is a paragraph with several lines. You can change style your text the way you want.\n\nFox example: "),
+        Text::styled("under", Style::default().fg(Color::Red)),
+        Text::raw(" "),
+        Text::styled("the", Style::default().fg(Color::Green)),
+        Text::raw(" "),
+        Text::styled("rainbow", Style::default().fg(Color::Blue)),
+        Text::raw(".\nOh and if you didn't "),
+        Text::styled("notice", Style::default().modifier(Modifier::Italic)),
+        Text::raw(" you can "),
+        Text::styled("automatically", Style::default().modifier(Modifier::Bold)),
+        Text::raw(" "),
+        Text::styled("wrap", Style::default().modifier(Modifier::Invert)),
+        Text::raw(" your "),
+        Text::styled("text", Style::default().modifier(Modifier::Underline)),
+        Text::raw(".\nOne more thing is that it should display unicode characters: 10€")
     ];
     Paragraph::new(text.iter())
         .block(

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -19,7 +19,7 @@ use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::canvas::{Canvas, Line, Map, MapResolution};
 use tui::widgets::{
-    Axis, BarChart, Block, Borders, Chart, Dataset, Gauge, Item, List, Marker, Paragraph, Row,
+    Axis, BarChart, Block, Borders, Chart, Dataset, Gauge, List, Marker, Paragraph, Row,
     SelectableList, Sparkline, Table, Tabs, Text, Widget,
 };
 use tui::{Frame, Terminal};
@@ -364,7 +364,7 @@ fn draw_charts(f: &mut Frame<MouseBackend>, app: &App, area: Rect) {
             let error_style = Style::default().fg(Color::Magenta);
             let critical_style = Style::default().fg(Color::Red);
             let events = app.events.iter().map(|&(evt, level)| {
-                Item::StyledData(
+                Text::styled(
                     format!("{}: {}", level, evt),
                     match level {
                         "ERROR" => error_style,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -439,21 +439,21 @@ fn draw_charts(f: &mut Frame<MouseBackend>, app: &App, area: Rect) {
 
 fn draw_text(f: &mut Frame<MouseBackend>, area: Rect) {
     let text = [
-        Text::Data("This is a paragraph with several lines. You can change style your text the way you want.\n\nFox example: "),
-        Text::StyledData("under", Style::default().fg(Color::Red)),
-        Text::Data(" "),
-        Text::StyledData("the", Style::default().fg(Color::Green)),
-        Text::Data(" "),
-        Text::StyledData("rainbow", Style::default().fg(Color::Blue)),
-        Text::Data(".\nOh and if you didn't "),
-        Text::StyledData("notice", Style::default().modifier(Modifier::Italic)),
-        Text::Data(" you can "),
-        Text::StyledData("automatically", Style::default().modifier(Modifier::Bold)),
-        Text::Data(" "),
-        Text::StyledData("wrap", Style::default().modifier(Modifier::Invert)),
-        Text::Data(" your "),
-        Text::StyledData("text", Style::default().modifier(Modifier::Underline)),
-        Text::Data(".\nOne more thing is that it should display unicode characters: 10€")
+        Text::Data("This is a paragraph with several lines. You can change style your text the way you want.\n\nFox example: ".into()),
+        Text::StyledData("under".into(), Style::default().fg(Color::Red)),
+        Text::Data(" ".into()),
+        Text::StyledData("the".into(), Style::default().fg(Color::Green)),
+        Text::Data(" ".into()),
+        Text::StyledData("rainbow".into(), Style::default().fg(Color::Blue)),
+        Text::Data(".\nOh and if you didn't ".into()),
+        Text::StyledData("notice".into(), Style::default().modifier(Modifier::Italic)),
+        Text::Data(" you can ".into()),
+        Text::StyledData("automatically".into(), Style::default().modifier(Modifier::Bold)),
+        Text::Data(" ".into()),
+        Text::StyledData("wrap".into(), Style::default().modifier(Modifier::Invert)),
+        Text::Data(" your ".into()),
+        Text::StyledData("text".into(), Style::default().modifier(Modifier::Underline)),
+        Text::Data(".\nOne more thing is that it should display unicode characters: 10€".into())
     ];
     Paragraph::new(text.iter())
         .block(

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -12,7 +12,7 @@ use termion::input::TermRead;
 use tui::backend::MouseBackend;
 use tui::layout::{Constraint, Corner, Direction, Layout, Rect};
 use tui::style::{Color, Modifier, Style};
-use tui::widgets::{Block, Borders, Item, List, SelectableList, Widget};
+use tui::widgets::{Block, Borders, List, SelectableList, Text, Widget};
 use tui::Terminal;
 
 struct App<'a> {
@@ -188,7 +188,7 @@ fn draw(t: &mut Terminal<MouseBackend>, app: &App) -> Result<(), io::Error> {
             .render(&mut f, chunks[0]);
         {
             let events = app.events.iter().map(|&(evt, level)| {
-                Item::StyledData(
+                Text::styled(
                     format!("{}: {}", level, evt),
                     match level {
                         "ERROR" => app.error_style,

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -55,14 +55,14 @@ fn draw(t: &mut Terminal<MouseBackend>, size: Rect) -> Result<(), io::Error> {
             .split(size);
 
         let text = [
-            Text::data("This a line\n"),
-            Text::styled_data("This a line\n", Style::default().fg(Color::Red)),
-            Text::styled_data("This a line\n", Style::default().bg(Color::Blue)),
-            Text::styled_data(
+            Text::raw("This a line\n"),
+            Text::styled("This a line\n", Style::default().fg(Color::Red)),
+            Text::styled("This a line\n", Style::default().bg(Color::Blue)),
+            Text::styled(
                 "This a longer line\n",
                 Style::default().modifier(Modifier::CrossedOut),
             ),
-            Text::styled_data(
+            Text::styled(
                 "This a line\n",
                 Style::default().fg(Color::Green).modifier(Modifier::Italic),
             ),

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -55,15 +55,15 @@ fn draw(t: &mut Terminal<MouseBackend>, size: Rect) -> Result<(), io::Error> {
             .split(size);
 
         let text = [
-            Text::Data("This a line\n"),
-            Text::StyledData("This a line\n", Style::default().fg(Color::Red)),
-            Text::StyledData("This a line\n", Style::default().bg(Color::Blue)),
+            Text::Data("This a line\n".into()),
+            Text::StyledData("This a line\n".into(), Style::default().fg(Color::Red)),
+            Text::StyledData("This a line\n".into(), Style::default().bg(Color::Blue)),
             Text::StyledData(
-                "This a longer line\n",
+                "This a longer line\n".into(),
                 Style::default().modifier(Modifier::CrossedOut),
             ),
             Text::StyledData(
-                "This a line\n",
+                "This a line\n".into(),
                 Style::default().fg(Color::Green).modifier(Modifier::Italic),
             ),
         ];

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -55,15 +55,15 @@ fn draw(t: &mut Terminal<MouseBackend>, size: Rect) -> Result<(), io::Error> {
             .split(size);
 
         let text = [
-            Text::Data("This a line\n".into()),
-            Text::StyledData("This a line\n".into(), Style::default().fg(Color::Red)),
-            Text::StyledData("This a line\n".into(), Style::default().bg(Color::Blue)),
-            Text::StyledData(
-                "This a longer line\n".into(),
+            Text::data("This a line\n"),
+            Text::styled_data("This a line\n", Style::default().fg(Color::Red)),
+            Text::styled_data("This a line\n", Style::default().bg(Color::Blue)),
+            Text::styled_data(
+                "This a longer line\n",
                 Style::default().modifier(Modifier::CrossedOut),
             ),
-            Text::StyledData(
-                "This a line\n".into(),
+            Text::styled_data(
+                "This a line\n",
                 Style::default().fg(Color::Green).modifier(Modifier::Italic),
             ),
         ];

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -22,7 +22,7 @@ use termion::input::TermRead;
 use tui::backend::AlternateScreenBackend;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Style};
-use tui::widgets::{Block, Borders, Item, List, Paragraph, Text, Widget};
+use tui::widgets::{Block, Borders, List, Paragraph, Text, Widget};
 use tui::Terminal;
 
 struct App {
@@ -122,7 +122,7 @@ fn draw(t: &mut Terminal<AlternateScreenBackend>, app: &App) -> Result<(), io::E
             app.messages
                 .iter()
                 .enumerate()
-                .map(|(i, m)| Item::Data(format!("{}: {}", i, m))),
+                .map(|(i, m)| Text::raw(format!("{}: {}", i, m))),
         ).block(Block::default().borders(Borders::ALL).title("Messages"))
             .render(&mut f, chunks[1]);
     })

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -114,7 +114,7 @@ fn draw(t: &mut Terminal<AlternateScreenBackend>, app: &App) -> Result<(), io::E
             .margin(2)
             .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
             .split(app.size);
-        Paragraph::new([Text::data(&app.input)].iter())
+        Paragraph::new([Text::raw(&app.input)].iter())
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("Input"))
             .render(&mut f, chunks[0]);

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -114,7 +114,7 @@ fn draw(t: &mut Terminal<AlternateScreenBackend>, app: &App) -> Result<(), io::E
             .margin(2)
             .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
             .split(app.size);
-        Paragraph::new([Text::Data((&app.input).into())].iter())
+        Paragraph::new([Text::data(&app.input)].iter())
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("Input"))
             .render(&mut f, chunks[0]);

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -114,7 +114,7 @@ fn draw(t: &mut Terminal<AlternateScreenBackend>, app: &App) -> Result<(), io::E
             .margin(2)
             .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
             .split(app.size);
-        Paragraph::new([Text::Data(&app.input)].iter())
+        Paragraph::new([Text::Data((&app.input).into())].iter())
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("Input"))
             .render(&mut f, chunks[0]);

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -15,7 +15,7 @@ pub use self::barchart::BarChart;
 pub use self::block::Block;
 pub use self::chart::{Axis, Chart, Dataset, Marker};
 pub use self::gauge::Gauge;
-pub use self::list::{Item, List, SelectableList};
+pub use self::list::{List, SelectableList};
 pub use self::paragraph::Paragraph;
 pub use self::sparkline::Sparkline;
 pub use self::table::{Row, Table};

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 mod barchart;
 mod block;
 pub mod canvas;
@@ -14,7 +16,7 @@ pub use self::block::Block;
 pub use self::chart::{Axis, Chart, Dataset, Marker};
 pub use self::gauge::Gauge;
 pub use self::list::{Item, List, SelectableList};
-pub use self::paragraph::{Paragraph, Text};
+pub use self::paragraph::Paragraph;
 pub use self::sparkline::Sparkline;
 pub use self::table::{Row, Table};
 pub use self::tabs::Tabs;
@@ -22,7 +24,7 @@ pub use self::tabs::Tabs;
 use backend::Backend;
 use buffer::Buffer;
 use layout::Rect;
-use style::Color;
+use style::{Color, Style};
 use terminal::Frame;
 
 /// Bitflags that can be composed to set the visible borders essentially on the block widget.
@@ -40,6 +42,21 @@ bitflags! {
         const LEFT = 0b0001_0000;
         /// Show all borders
         const ALL = Self::TOP.bits | Self::RIGHT.bits | Self::BOTTOM.bits | Self::LEFT.bits;
+    }
+}
+
+pub enum Text<'b> {
+    Raw(Cow<'b, str>),
+    Styled(Cow<'b, str>, Style),
+}
+
+impl<'b> Text<'b> {
+    pub fn raw<D: Into<Cow<'b, str>>>(data: D) -> Text<'b> {
+        Text::Raw(data.into())
+    }
+
+    pub fn styled<D: Into<Cow<'b, str>>>(data: D, style: Style) -> Text<'b> {
+        Text::Styled(data.into(), style)
     }
 }
 

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -21,8 +21,8 @@ use widgets::{Block, Widget};
 /// # use tui::layout::{Alignment};
 /// # fn main() {
 /// let text = [
-///     Text::Data("First line\n"),
-///     Text::StyledData("Second line\n", Style::default().fg(Color::Red))
+///     Text::Data("First line\n".into()),
+///     Text::StyledData("Second line\n".into(), Style::default().fg(Color::Red))
 /// ];
 /// Paragraph::new(text.iter())
 ///     .block(Block::default().title("Paragraph").borders(Borders::ALL))

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use either::Either;
 use itertools::{multipeek, MultiPeek};
 use unicode_segmentation::UnicodeSegmentation;
@@ -50,8 +52,8 @@ where
 }
 
 pub enum Text<'b> {
-    Data(&'b str),
-    StyledData(&'b str, Style),
+    Data(Cow<'b, str>),
+    StyledData(Cow<'b, str>, Style),
 }
 
 impl<'a, 't, T> Paragraph<'a, 't, T>
@@ -122,11 +124,13 @@ where
 
         let style = self.style;
         let styled = self.text.by_ref().flat_map(|t| match *t {
-            Text::Data(d) => {
-                Either::Left(UnicodeSegmentation::graphemes(d, true).map(|g| (g, style)))
+            Text::Data(ref d) => {
+                let data: &'t str = d; // coerce to &str
+                Either::Left(UnicodeSegmentation::graphemes(data, true).map(|g| (g, style)))
             }
-            Text::StyledData(d, s) => {
-                Either::Right(UnicodeSegmentation::graphemes(d, true).map(move |g| (g, s)))
+            Text::StyledData(ref d, s) => {
+                let data: &'t str = d; // coerce to &str
+                Either::Right(UnicodeSegmentation::graphemes(data, true).map(move |g| (g, s)))
             }
         });
         let mut styled = multipeek(styled);

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -21,8 +21,8 @@ use widgets::{Block, Widget};
 /// # use tui::layout::{Alignment};
 /// # fn main() {
 /// let text = [
-///     Text::data("First line\n"),
-///     Text::styled_data("Second line\n", Style::default().fg(Color::Red))
+///     Text::raw("First line\n"),
+///     Text::styled("Second line\n", Style::default().fg(Color::Red))
 /// ];
 /// Paragraph::new(text.iter())
 ///     .block(Block::default().title("Paragraph").borders(Borders::ALL))
@@ -52,17 +52,17 @@ where
 }
 
 pub enum Text<'b> {
-    Data(Cow<'b, str>),
-    StyledData(Cow<'b, str>, Style),
+    Raw(Cow<'b, str>),
+    Styled(Cow<'b, str>, Style),
 }
 
 impl<'b> Text<'b> {
-    pub fn data<D: Into<Cow<'b, str>>>(data: D) -> Text<'b> {
-        Text::Data(data.into())
+    pub fn raw<D: Into<Cow<'b, str>>>(data: D) -> Text<'b> {
+        Text::Raw(data.into())
     }
 
-    pub fn styled_data<D: Into<Cow<'b, str>>>(data: D, style: Style) -> Text<'b> {
-        Text::StyledData(data.into(), style)
+    pub fn styled<D: Into<Cow<'b, str>>>(data: D, style: Style) -> Text<'b> {
+        Text::Styled(data.into(), style)
     }
 }
 
@@ -134,11 +134,11 @@ where
 
         let style = self.style;
         let styled = self.text.by_ref().flat_map(|t| match *t {
-            Text::Data(ref d) => {
+            Text::Raw(ref d) => {
                 let data: &'t str = d; // coerce to &str
                 Either::Left(UnicodeSegmentation::graphemes(data, true).map(|g| (g, style)))
             }
-            Text::StyledData(ref d, s) => {
+            Text::Styled(ref d, s) => {
                 let data: &'t str = d; // coerce to &str
                 Either::Right(UnicodeSegmentation::graphemes(data, true).map(move |g| (g, s)))
             }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -21,8 +21,8 @@ use widgets::{Block, Widget};
 /// # use tui::layout::{Alignment};
 /// # fn main() {
 /// let text = [
-///     Text::Data("First line\n".into()),
-///     Text::StyledData("Second line\n".into(), Style::default().fg(Color::Red))
+///     Text::data("First line\n"),
+///     Text::styled_data("Second line\n", Style::default().fg(Color::Red))
 /// ];
 /// Paragraph::new(text.iter())
 ///     .block(Block::default().title("Paragraph").borders(Borders::ALL))
@@ -54,6 +54,16 @@ where
 pub enum Text<'b> {
     Data(Cow<'b, str>),
     StyledData(Cow<'b, str>, Style),
+}
+
+impl<'b> Text<'b> {
+    pub fn data<D: Into<Cow<'b, str>>>(data: D) -> Text<'b> {
+        Text::Data(data.into())
+    }
+
+    pub fn styled_data<D: Into<Cow<'b, str>>>(data: D, style: Style) -> Text<'b> {
+        Text::StyledData(data.into(), style)
+    }
 }
 
 impl<'a, 't, T> Paragraph<'a, 't, T>

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use either::Either;
 use itertools::{multipeek, MultiPeek};
 use unicode_segmentation::UnicodeSegmentation;
@@ -8,7 +6,7 @@ use unicode_width::UnicodeWidthStr;
 use buffer::Buffer;
 use layout::{Alignment, Rect};
 use style::Style;
-use widgets::{Block, Widget};
+use widgets::{Block, Text, Widget};
 
 /// A widget to display some text.
 ///
@@ -49,21 +47,6 @@ where
     scroll: u16,
     /// Aligenment of the text
     alignment: Alignment,
-}
-
-pub enum Text<'b> {
-    Raw(Cow<'b, str>),
-    Styled(Cow<'b, str>, Style),
-}
-
-impl<'b> Text<'b> {
-    pub fn raw<D: Into<Cow<'b, str>>>(data: D) -> Text<'b> {
-        Text::Raw(data.into())
-    }
-
-    pub fn styled<D: Into<Cow<'b, str>>>(data: D, style: Style) -> Text<'b> {
-        Text::Styled(data.into(), style)
-    }
 }
 
 impl<'a, 't, T> Paragraph<'a, 't, T>


### PR DESCRIPTION
I took a crack at fixing issue #70 and here's what it looks like. The slightly annoying thing is having to add `.into()` when building a `Text`. If that's too annoying we can maybe add some helper methods like `Text::data()` and `Text::styled_data()` that would do the conversion for you.