### PR TITLE
Limit Rect size to prevent u16 overflow

### DIFF
--- a/examples/rustbox.rs
+++ b/examples/rustbox.rs
@@ -5,17 +5,16 @@ use rustbox::Key;
 use std::error::Error;
 
 use tui::backend::RustboxBackend;
-use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
-use tui::widgets::{Block, Borders, Paragraph, Widget};
+use tui::widgets::{Block, Borders, Paragraph, Text, Widget};
 use tui::Terminal;
 
-fn main() {
+fn main() -> Result<(), failure::Error> {
     let mut terminal = Terminal::new(RustboxBackend::new().unwrap()).unwrap();
     terminal.clear().unwrap();
     terminal.hide_cursor().unwrap();
-    draw(&mut terminal);
     loop {
+        draw(&mut terminal)?;
         match terminal.backend().rustbox().poll_event(false) {
             Ok(rustbox::Event::KeyEvent(key)) => if key == Key::Char('q') {
                 break;
@@ -23,25 +22,25 @@ fn main() {
             Err(e) => panic!("{}", e.description()),
             _ => {}
         };
-        draw(&mut terminal);
     }
-    terminal.show_cursor().unwrap();
+    terminal.show_cursor()?;
+    Ok(())
 }
 
-fn draw(t: &mut Terminal<RustboxBackend>) {
-    let size = t.size().unwrap();
-    {
-        let mut f = t.get_frame();
-        Paragraph::default()
+fn draw(t: &mut Terminal<RustboxBackend>) -> Result<(), std::io::Error> {
+    let size = t.size()?;
+    let text = [
+        Text::raw("It "),
+        Text::styled("works", Style::default().fg(Color::Yellow)),
+    ];
+    t.draw(|mut f| {
+        Paragraph::new(text.iter())
             .block(
                 Block::default()
                     .title("Rustbox backend")
                     .title_style(Style::default().fg(Color::Yellow).modifier(Modifier::Bold))
                     .borders(Borders::ALL)
                     .border_style(Style::default().fg(Color::Magenta)),
-            ).text("It {yellow works}!")
-            .render(&mut f, &size);
-    }
-
-    t.draw().unwrap();
+            ).render(&mut f, size)
+    })
 }

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -45,12 +45,7 @@ impl Backend for CrosstermBackend {
     fn size(&self) -> io::Result<Rect> {
         let terminal = crossterm::terminal::terminal(&self.screen);
         let (width, height) = terminal.terminal_size();
-        Ok(Rect {
-            x: 0,
-            y: 0,
-            width,
-            height,
-        })
+        Ok(Rect::new(0, 0, width, height))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/backend/rustbox.rs
+++ b/src/backend/rustbox.rs
@@ -57,12 +57,23 @@ impl Backend for RustboxBackend {
         Ok(())
     }
     fn size(&self) -> Result<Rect, io::Error> {
-        Ok(Rect {
-            x: 0,
-            y: 0,
-            width: self.rustbox.width() as u16,
-            height: self.rustbox.height() as u16,
-        })
+        let term_width = self.rustbox.width();
+        let term_height = self.rustbox.height();
+        let max = u16::max_value();
+        Ok(Rect::new(
+            0,
+            0,
+            if term_width > usize::from(max) {
+                max
+            } else {
+                term_width as u16
+            },
+            if term_height > usize::from(max) {
+                max
+            } else {
+                term_height as u16
+            },
+        ))
     }
     fn flush(&mut self) -> Result<(), io::Error> {
         self.rustbox.present();

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -112,12 +112,7 @@ where
     /// Return the size of the terminal
     fn size(&self) -> io::Result<Rect> {
         let terminal = try!(termion::terminal_size());
-        Ok(Rect {
-            x: 0,
-            y: 0,
-            width: terminal.0,
-            height: terminal.1,
-        })
+        Ok(Rect::new(0, 0, terminal.0, terminal.1))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -16,12 +16,7 @@ impl TestBackend {
         TestBackend {
             width,
             height,
-            buffer: Buffer::empty(Rect {
-                x: 0,
-                y: 0,
-                width,
-                height,
-            }),
+            buffer: Buffer::empty(Rect::new(0, 0, width, height)),
             cursor: false,
         }
     }
@@ -55,12 +50,7 @@ impl Backend for TestBackend {
         Ok(())
     }
     fn size(&self) -> Result<Rect, io::Error> {
-        Ok(Rect {
-            x: 0,
-            y: 0,
-            width: self.width,
-            height: self.height,
-        })
+        Ok(Rect::new(0, 0, self.width, self.height))
     }
     fn flush(&mut self) -> Result<(), io::Error> {
         Ok(())

--- a/tests/size.rs
+++ b/tests/size.rs
@@ -1,0 +1,13 @@
+extern crate tui;
+
+use tui::backend::{Backend, TestBackend};
+use tui::Terminal;
+
+#[test]
+fn buffer_size_limited() {
+    let backend = TestBackend::new(400, 400);
+    let terminal = Terminal::new(backend).unwrap();
+    let size = terminal.backend().size().unwrap();
+    assert_eq!(size.width, 255);
+    assert_eq!(size.height, 255);
+}


### PR DESCRIPTION
This pull request can be also interpreted as a reason to reconsider using `u32` or `usize` for dimensions. Even then, checking for overflow won't hurt.

Demo: https://streamable.com/iqxi7 (max area reduced from max u16 to 5000 for demo purposes)