### PR TITLE
Feature: Autoresize

### DIFF
--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -12,7 +12,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{BarChart, Block, Borders, Widget};
 use tui::Terminal;
@@ -20,14 +20,12 @@ use tui::Terminal;
 use util::event::{Event, Events};
 
 struct App<'a> {
-    size: Rect,
     data: Vec<(&'a str, u64)>,
 }
 
 impl<'a> App<'a> {
     fn new() -> App<'a> {
         App {
-            size: Rect::default(),
             data: vec![
                 ("B1", 9),
                 ("B2", 12),
@@ -80,16 +78,12 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if app.size != size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
         terminal.draw(|mut f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-                .split(app.size);
+                .split(size);
             BarChart::default()
                 .block(Block::default().title("Data1").borders(Borders::ALL))
                 .data(&app.data)

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -11,24 +11,12 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Borders, Widget};
 use tui::Terminal;
 
 use util::event::{Event, Events};
-
-struct App {
-    size: Rect,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            size: Rect::default(),
-        }
-    }
-}
 
 fn main() -> Result<(), failure::Error> {
     // Terminal initialization
@@ -39,18 +27,11 @@ fn main() -> Result<(), failure::Error> {
     let mut terminal = Terminal::new(backend)?;
     terminal.hide_cursor()?;
 
-    // Create default app state
-    let mut app = App::default();
-
     // Setup event handlers
     let events = Events::new();
 
     loop {
         let size = terminal.size()?;
-        if app.size != size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             // Wrapping block for a group
@@ -61,7 +42,7 @@ fn main() -> Result<(), failure::Error> {
                 .direction(Direction::Vertical)
                 .margin(4)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-                .split(app.size);
+                .split(size);
             {
                 let chunks = Layout::default()
                     .direction(Direction::Horizontal)

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -22,7 +22,6 @@ use tui::Terminal;
 use util::event::{Config, Event, Events};
 
 struct App {
-    size: Rect,
     x: f64,
     y: f64,
     ball: Rect,
@@ -36,7 +35,6 @@ struct App {
 impl App {
     fn new() -> App {
         App {
-            size: Default::default(),
             x: 0.0,
             y: 0.0,
             ball: Rect::new(10, 30, 10, 10),
@@ -93,16 +91,12 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-                .split(app.size);
+                .split(size);
             Canvas::default()
                 .block(Block::default().borders(Borders::ALL).title("World"))
                 .paint(|ctx| {

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -12,7 +12,6 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::Rect;
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Axis, Block, Borders, Chart, Dataset, Marker, Widget};
 use tui::Terminal;
@@ -21,7 +20,6 @@ use util::event::{Event, Events};
 use util::SinSignal;
 
 struct App {
-    size: Rect,
     signal1: SinSignal,
     data1: Vec<(f64, f64)>,
     signal2: SinSignal,
@@ -36,7 +34,6 @@ impl App {
         let data1 = signal1.by_ref().take(200).collect::<Vec<(f64, f64)>>();
         let data2 = signal2.by_ref().take(200).collect::<Vec<(f64, f64)>>();
         App {
-            size: Rect::default(),
             signal1,
             data1,
             signal2,
@@ -75,10 +72,6 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if app.size != size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             Chart::default()
@@ -116,7 +109,7 @@ fn main() -> Result<(), failure::Error> {
                         .marker(Marker::Braille)
                         .style(Style::default().fg(Color::Yellow))
                         .data(&app.data2),
-                ]).render(&mut f, app.size);
+                ]).render(&mut f, size);
         })?;
 
         match events.next()? {

--- a/examples/crossterm.rs
+++ b/examples/crossterm.rs
@@ -3,34 +3,17 @@ extern crate failure;
 extern crate tui;
 
 use tui::backend::CrosstermBackend;
-use tui::layout::Rect;
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Borders, Paragraph, Text, Widget};
 use tui::Terminal;
-
-struct App {
-    size: Rect,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            size: Rect::default(),
-        }
-    }
-}
 
 fn main() -> Result<(), failure::Error> {
     let mut terminal = Terminal::new(CrosstermBackend::new())?;
     terminal.clear()?;
     terminal.hide_cursor()?;
-    let mut app = App::default();
+
     loop {
         let size = terminal.size()?;
-        if app.size != size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let text = [

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -20,18 +20,6 @@ use tui::Terminal;
 
 use util::event::{Event, Events};
 
-struct App {
-    size: Rect,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            size: Rect::default(),
-        }
-    }
-}
-
 struct Label<'a> {
     text: &'a str,
 }
@@ -65,17 +53,11 @@ fn main() -> Result<(), failure::Error> {
 
     let events = Events::new();
 
-    let mut app = App::default();
-
     loop {
         let size = terminal.size()?;
-        if app.size != size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
-            Label::default().text("Test").render(&mut f, app.size);
+            Label::default().text("Test").render(&mut f, size);
         })?;
 
         match events.next()? {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -34,7 +34,6 @@ struct Server<'a> {
 }
 
 struct App<'a> {
-    size: Rect,
     items: Vec<&'a str>,
     events: Vec<(&'a str, &'a str)>,
     selected: usize,
@@ -71,7 +70,6 @@ fn main() -> Result<(), failure::Error> {
     let mut sin_signal2 = SinSignal::new(0.1, 2.0, 10.0);
 
     let mut app = App {
-        size: Rect::default(),
         items: vec![
             "Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9",
             "Item10", "Item11", "Item12", "Item13", "Item14", "Item15", "Item16", "Item17",
@@ -171,16 +169,12 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         // Draw UI
         terminal.draw(|mut f| {
             let chunks = Layout::default()
                 .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
-                .split(app.size);
+                .split(size);
             Tabs::default()
                 .block(Block::default().borders(Borders::ALL).title("Tabs"))
                 .titles(&app.tabs.titles)

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -12,7 +12,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Borders, Gauge, Widget};
 use tui::Terminal;
@@ -20,7 +20,6 @@ use tui::Terminal;
 use util::event::{Event, Events};
 
 struct App {
-    size: Rect,
     progress1: u16,
     progress2: u16,
     progress3: u16,
@@ -30,7 +29,6 @@ struct App {
 impl App {
     fn new() -> App {
         App {
-            size: Rect::default(),
             progress1: 0,
             progress2: 0,
             progress3: 0,
@@ -73,10 +71,6 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let chunks = Layout::default()
@@ -90,7 +84,8 @@ fn main() -> Result<(), failure::Error> {
                         Constraint::Percentage(25),
                     ]
                         .as_ref(),
-                ).split(app.size);
+                ).split(size);
+
             Gauge::default()
                 .block(Block::default().title("Gauge1").borders(Borders::ALL))
                 .style(Style::default().fg(Color::Yellow))

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -14,23 +14,11 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::widgets::{Block, Borders, Widget};
 use tui::Terminal;
 
 use util::event::{Event, Events};
-
-struct App {
-    size: Rect,
-}
-
-impl App {
-    fn new() -> App {
-        App {
-            size: Rect::default(),
-        }
-    }
-}
 
 fn main() -> Result<(), failure::Error> {
     stderrlog::new().verbosity(4).init()?;
@@ -45,15 +33,8 @@ fn main() -> Result<(), failure::Error> {
 
     let events = Events::new();
 
-    // App
-    let mut app = App::new();
-
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let chunks = Layout::default()
@@ -65,7 +46,7 @@ fn main() -> Result<(), failure::Error> {
                         Constraint::Percentage(10),
                     ]
                         .as_ref(),
-                ).split(app.size);
+                ).split(size);
 
             Block::default()
                 .title("Block")

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -12,7 +12,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Corner, Direction, Layout, Rect};
+use tui::layout::{Constraint, Corner, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Borders, List, SelectableList, Text, Widget};
 use tui::Terminal;
@@ -20,7 +20,6 @@ use tui::Terminal;
 use util::event::{Event, Events};
 
 struct App<'a> {
-    size: Rect,
     items: Vec<&'a str>,
     selected: Option<usize>,
     events: Vec<(&'a str, &'a str)>,
@@ -33,7 +32,6 @@ struct App<'a> {
 impl<'a> App<'a> {
     fn new() -> App<'a> {
         App {
-            size: Rect::default(),
             items: vec![
                 "Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9",
                 "Item10", "Item11", "Item12", "Item13", "Item14", "Item15", "Item16", "Item17",
@@ -97,16 +95,12 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-                .split(app.size);
+                .split(size);
 
             let style = Style::default().fg(Color::Black).bg(Color::White);
             SelectableList::default()

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -12,24 +12,12 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use tui::layout::{Alignment, Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Paragraph, Text, Widget};
 use tui::Terminal;
 
 use util::event::{Event, Events};
-
-struct App {
-    size: Rect,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            size: Rect::default(),
-        }
-    }
-}
 
 fn main() -> Result<(), failure::Error> {
     // Terminal initialization
@@ -42,14 +30,8 @@ fn main() -> Result<(), failure::Error> {
 
     let events = Events::new();
 
-    let mut app = App::default();
-
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         let mut long_line: String = std::iter::repeat('X').take(size.width.into()).collect();
         long_line.insert_str(0, "Very long line: ");

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -12,7 +12,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Style};
 use tui::widgets::{Block, Borders, Sparkline, Widget};
 use tui::Terminal;
@@ -21,7 +21,6 @@ use util::event::{Event, Events};
 use util::RandomSignal;
 
 struct App {
-    size: Rect,
     signal: RandomSignal,
     data1: Vec<u64>,
     data2: Vec<u64>,
@@ -35,7 +34,6 @@ impl App {
         let data2 = signal.by_ref().take(200).collect::<Vec<u64>>();
         let data3 = signal.by_ref().take(200).collect::<Vec<u64>>();
         App {
-            size: Rect::default(),
             signal,
             data1,
             data2,
@@ -73,10 +71,6 @@ fn main() -> Result<(), failure::Error> {
 
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let chunks = Layout::default()
@@ -90,7 +84,7 @@ fn main() -> Result<(), failure::Error> {
                         Constraint::Min(0),
                     ]
                         .as_ref(),
-                ).split(app.size);
+                ).split(size);
             Sparkline::default()
                 .block(
                     Block::default()

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -12,7 +12,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Layout, Rect};
+use tui::layout::{Constraint, Layout};
 use tui::style::{Color, Modifier, Style};
 use tui::widgets::{Block, Borders, Row, Table, Widget};
 use tui::Terminal;
@@ -20,7 +20,6 @@ use tui::Terminal;
 use util::event::{Event, Events};
 
 struct App<'a> {
-    size: Rect,
     items: Vec<Vec<&'a str>>,
     selected: usize,
 }
@@ -28,7 +27,6 @@ struct App<'a> {
 impl<'a> App<'a> {
     fn new() -> App<'a> {
         App {
-            size: Rect::default(),
             items: vec![
                 vec!["Row12", "Row12", "Row13"],
                 vec!["Row21", "Row22", "Row23"],
@@ -59,10 +57,6 @@ fn main() -> Result<(), failure::Error> {
     // Input
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let selected_style = Style::default().fg(Color::Yellow).modifier(Modifier::Bold);
@@ -79,7 +73,7 @@ fn main() -> Result<(), failure::Error> {
             let rects = Layout::default()
                 .constraints([Constraint::Percentage(100)].as_ref())
                 .margin(5)
-                .split(app.size);
+                .split(size);
             Table::new(header.into_iter(), rows)
                 .block(Block::default().borders(Borders::ALL).title("Table"))
                 .widths(&[10, 10, 10])

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -12,7 +12,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Style};
 use tui::widgets::{Block, Borders, Tabs, Widget};
 use tui::Terminal;
@@ -21,7 +21,6 @@ use util::event::{Event, Events};
 use util::TabsState;
 
 struct App<'a> {
-    size: Rect,
     tabs: TabsState<'a>,
 }
 
@@ -38,28 +37,23 @@ fn main() -> Result<(), failure::Error> {
 
     // App
     let mut app = App {
-        size: Rect::default(),
         tabs: TabsState::new(vec!["Tab0", "Tab1", "Tab2", "Tab3"]),
     };
 
     // Main loop
     loop {
         let size = terminal.size()?;
-        if size != app.size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         terminal.draw(|mut f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(5)
                 .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
-                .split(app.size);
+                .split(size);
 
             Block::default()
                 .style(Style::default().bg(Color::White))
-                .render(&mut f, app.size);
+                .render(&mut f, size);
             Tabs::default()
                 .block(Block::default().borders(Borders::ALL).title("Tabs"))
                 .titles(&app.tabs.titles)

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -25,7 +25,7 @@ use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Style};
 use tui::widgets::{Block, Borders, List, Paragraph, Text, Widget};
 use tui::Terminal;
@@ -35,8 +35,6 @@ use util::event::{Event, Events};
 
 /// App holds the state of the application
 struct App {
-    /// Current size of the terminal
-    size: Rect,
     /// Current value of the input box
     input: String,
     /// History of recorded messages
@@ -46,7 +44,6 @@ struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            size: Rect::default(),
             input: String::new(),
             messages: Vec::new(),
         }
@@ -70,10 +67,6 @@ fn main() -> Result<(), failure::Error> {
     loop {
         // Handle resize
         let size = terminal.size()?;
-        if app.size != size {
-            terminal.resize(size)?;
-            app.size = size;
-        }
 
         // Draw UI
         terminal.draw(|mut f| {
@@ -81,7 +74,7 @@ fn main() -> Result<(), failure::Error> {
                 .direction(Direction::Vertical)
                 .margin(2)
                 .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
-                .split(app.size);
+                .split(size);
             Paragraph::new([Text::raw(&app.input)].iter())
                 .style(Style::default().fg(Color::Yellow))
                 .block(Block::default().borders(Borders::ALL).title("Input"))


### PR DESCRIPTION
It basically never makes sense to render without syncing the size.

Without resizing, if shrinking, we get artefacts. If growing, we may get
panics (before this change the Rustbox sample (the only one which didn't
handle resizing on its own) panicked because the widget would get an
updated size, while the terminal would not).