### PR TITLE
Make sure we always emit a cursor goto for the first update.

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -59,9 +59,11 @@ impl Backend for CrosstermBackend {
         let cursor = crossterm::cursor();
         let mut last_y = 0;
         let mut last_x = 0;
+        let mut first = true;
         for (x, y, cell) in content {
-            if y != last_y || x != last_x + 1 {
+            if y != last_y || x != last_x + 1 || first {
                 cursor.goto(x, y);
+                first = false;
             }
             last_x = x;
             last_y = y;

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -70,7 +70,7 @@ where
         let mut last_x = 0;
         let mut inst = 0;
         for (x, y, cell) in content {
-            if y != last_y || x != last_x + 1 {
+            if y != last_y || x != last_x + 1 || inst == 0 {
                 string.push_str(&format!("{}", termion::cursor::Goto(x + 1, y + 1)));
                 inst += 1;
             }


### PR DESCRIPTION
Otherwise, if the first update is to (1, 0) then no goto occurs. Something like this reproduces the error, producing "Playause" on the second update.

```rust
use termion::raw::IntoRawMode;
use tui;
use tui::widgets::Widget;

fn main() -> Result<(), failure::Error> {
    let stdout = std::io::stdout().into_raw_mode()?;
    let stdout = termion::screen::AlternateScreen::from(stdout);
    let backend = tui::backend::TermionBackend::new(stdout);
    let mut terminal = tui::Terminal::new(backend)?;
    let size = terminal.size()?;

    for i in ["Play", "Pause"].iter() {
        terminal.draw(|mut f| {
            let line = [tui::widgets::Text::raw(i.clone())];
            tui::widgets::Paragraph::new(line.iter()).render(&mut f, size);
        });
        std::thread::sleep(std::time::Duration::from_millis(1000));
    }
    Ok(())
}
```
