### PR TITLE
Paragraph - line wrapping on word boundaries

### DIFF
--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -30,12 +30,13 @@ fn main() -> Result<(), failure::Error> {
 
     let events = Events::new();
 
+    let mut scroll: u16 = 0;
     loop {
         terminal.draw(|mut f| {
             let size = f.size();
 
             // Words made "loooong" to demonstrate line breaking.
-            let s = "Veeeeeeeeeeeeeeeery loooooooooooooooooong striiiiiiiiiiiiiiiiiiiiiiiiiing. ";
+            let s = "Veeeeeeeeeeeeeeeery    loooooooooooooooooong   striiiiiiiiiiiiiiiiiiiiiiiiiing.   ";
             let mut long_line = s.repeat(usize::from(size.width) / s.len() + 4);
             long_line.push('\n');
 
@@ -58,16 +59,16 @@ fn main() -> Result<(), failure::Error> {
                 .split(size);
 
             let text = [
-                Text::raw("This a line\n"),
-                Text::styled("This a line\n", Style::default().fg(Color::Red)),
-                Text::styled("This a line\n", Style::default().bg(Color::Blue)),
+                Text::raw("This is a line \n"),
+                Text::styled("This is a line   \n", Style::default().fg(Color::Red)),
+                Text::styled("This is a line\n", Style::default().bg(Color::Blue)),
                 Text::styled(
-                    "This a longer line\n",
+                    "This is a longer line\n",
                     Style::default().modifier(Modifier::CrossedOut),
                 ),
-                Text::raw(&long_line),
+                Text::styled(&long_line, Style::default().bg(Color::Green)),
                 Text::styled(
-                    "This a line\n",
+                    "This is a line\n",
                     Style::default().fg(Color::Green).modifier(Modifier::Italic),
                 ),
             ];
@@ -88,6 +89,7 @@ fn main() -> Result<(), failure::Error> {
                 .block(block.clone().title("Center, wrap"))
                 .alignment(Alignment::Center)
                 .wrap(true)
+                .scroll(scroll)
                 .render(&mut f, chunks[2]);
             Paragraph::new(text.iter())
                 .block(block.clone().title("Right, wrap"))
@@ -95,6 +97,9 @@ fn main() -> Result<(), failure::Error> {
                 .wrap(true)
                 .render(&mut f, chunks[3]);
         })?;
+
+        scroll += 1;
+        scroll %= 10;
 
         match events.next()? {
             Event::Input(key) => {

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -14,7 +14,7 @@ use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
 use tui::layout::{Alignment, Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
-use tui::widgets::{Block, Paragraph, Text, Widget};
+use tui::widgets::{Block, Borders, Paragraph, Text, Widget};
 use tui::Terminal;
 
 use util::event::{Event, Events};
@@ -34,8 +34,9 @@ fn main() -> Result<(), failure::Error> {
         terminal.draw(|mut f| {
             let size = f.size();
 
-            let mut long_line: String = std::iter::repeat('X').take(size.width.into()).collect();
-            long_line.insert_str(0, "Very long line: ");
+            // Words made "loooong" to demonstrate line breaking.
+            let s = "Veeeeeeeeeeeeeeeery loooooooooooooooooong striiiiiiiiiiiiiiiiiiiiiiiiiing. ";
+            let mut long_line = s.repeat(usize::from(size.width) / s.len() + 4);
             long_line.push('\n');
 
             Block::default()
@@ -47,9 +48,10 @@ fn main() -> Result<(), failure::Error> {
                 .margin(5)
                 .constraints(
                     [
-                        Constraint::Percentage(30),
-                        Constraint::Percentage(30),
-                        Constraint::Percentage(30),
+                        Constraint::Percentage(25),
+                        Constraint::Percentage(25),
+                        Constraint::Percentage(25),
+                        Constraint::Percentage(25),
                     ]
                     .as_ref(),
                 )
@@ -70,17 +72,28 @@ fn main() -> Result<(), failure::Error> {
                 ),
             ];
 
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title_style(Style::default().modifier(Modifier::Bold));
             Paragraph::new(text.iter())
+                .block(block.clone().title("Left, no wrap"))
                 .alignment(Alignment::Left)
                 .render(&mut f, chunks[0]);
             Paragraph::new(text.iter())
-                .alignment(Alignment::Center)
+                .block(block.clone().title("Left, wrap"))
+                .alignment(Alignment::Left)
                 .wrap(true)
                 .render(&mut f, chunks[1]);
             Paragraph::new(text.iter())
-                .alignment(Alignment::Right)
+                .block(block.clone().title("Center, wrap"))
+                .alignment(Alignment::Center)
                 .wrap(true)
                 .render(&mut f, chunks[2]);
+            Paragraph::new(text.iter())
+                .block(block.clone().title("Right, wrap"))
+                .alignment(Alignment::Right)
+                .wrap(true)
+                .render(&mut f, chunks[3]);
         })?;
 
         match events.next()? {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::usize;
 
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
 
 use layout::Rect;
 use style::{Color, Modifier, Style};
@@ -163,7 +162,10 @@ impl Buffer {
     {
         let height = lines.len() as u16;
         let width = lines.iter().fold(0, |acc, item| {
-            std::cmp::max(acc, item.as_ref().width() as u16)
+            std::cmp::max(
+                acc,
+                UnicodeSegmentation::graphemes(item.as_ref(), true).count() as u16,
+            )
         });
         let mut buffer = Buffer::empty(Rect {
             x: 0,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -7,6 +7,7 @@ mod chart;
 mod gauge;
 mod list;
 mod paragraph;
+mod reflow;
 mod sparkline;
 mod table;
 mod tabs;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -166,7 +166,9 @@ where
                 y += 1;
                 continue;
             }
-            if x >= text_area.width {
+            let token_end_index = x + string.width() as u16 - 1;
+            let last_column_index = text_area.width - 1;
+            if token_end_index > last_column_index {
                 if !self.wrapping {
                     continue; // Truncate the remainder of the line.
                 } else {

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -1,0 +1,446 @@
+use style::Style;
+use unicode_width::UnicodeWidthStr;
+
+const NBSP: &str = "\u{00a0}";
+
+#[derive(Copy, Clone, Debug)]
+pub struct Styled<'a>(pub &'a str, pub Style);
+
+/// A state machine to pack styled symbols into lines.
+/// Cannot implement it as Iterator since it yields slices of the internal buffer (need streaming
+/// iterators for that).
+pub trait LineComposer<'a> {
+    fn next_line(&mut self) -> Option<(&[Styled<'a>], u16)>;
+}
+
+/// A state machine that wraps lines on word boundaries.
+pub struct WordWrapper<'a, 'b> {
+    symbols: &'b mut Iterator<Item = Styled<'a>>,
+    max_line_width: u16,
+    current_line: Vec<Styled<'a>>,
+    next_line: Vec<Styled<'a>>,
+}
+
+impl<'a, 'b> WordWrapper<'a, 'b> {
+    pub fn new(
+        symbols: &'b mut Iterator<Item = Styled<'a>>,
+        max_line_width: u16,
+    ) -> WordWrapper<'a, 'b> {
+        WordWrapper {
+            symbols,
+            max_line_width,
+            current_line: vec![],
+            next_line: vec![],
+        }
+    }
+}
+
+impl<'a, 'b> LineComposer<'a> for WordWrapper<'a, 'b> {
+    fn next_line(&mut self) -> Option<(&[Styled<'a>], u16)> {
+        if self.max_line_width == 0 {
+            return None;
+        }
+        std::mem::swap(&mut self.current_line, &mut self.next_line);
+        self.next_line.truncate(0);
+
+        let mut current_line_width = self
+            .current_line
+            .iter()
+            .map(|Styled(c, _)| c.width() as u16)
+            .sum();
+
+        let mut symbols_to_last_word_end: usize = 0;
+        let mut width_to_last_word_end: u16 = 0;
+        let mut prev_whitespace = false;
+        let mut symbols_exhausted = true;
+        for Styled(symbol, style) in &mut self.symbols {
+            symbols_exhausted = false;
+            let symbol_whitespace = symbol.chars().all(&char::is_whitespace);
+
+            // Ignore characters wider that the total max width.
+            if symbol.width() as u16 > self.max_line_width
+                // Skip leading whitespace.
+                || symbol_whitespace && symbol != "\n" && current_line_width == 0
+            {
+                continue;
+            }
+
+            // Break on newline and discard it.
+            if symbol == "\n" {
+                if prev_whitespace {
+                    current_line_width = width_to_last_word_end;
+                    self.current_line.truncate(symbols_to_last_word_end);
+                }
+                break;
+            }
+
+            // Mark the previous symbol as word end.
+            if symbol_whitespace && !prev_whitespace && symbol != NBSP {
+                symbols_to_last_word_end = self.current_line.len();
+                width_to_last_word_end = current_line_width;
+            }
+
+            self.current_line.push(Styled(symbol, style));
+            current_line_width += symbol.width() as u16;
+
+            if current_line_width > self.max_line_width {
+                // If there was no word break in the text, wrap at the end of the line.
+                let (truncate_at, truncated_width) = if symbols_to_last_word_end != 0 {
+                    (symbols_to_last_word_end, width_to_last_word_end)
+                } else {
+                    (self.current_line.len() - 1, self.max_line_width)
+                };
+
+                // Push the remainder to the next line but strip leading whitespace:
+                {
+                    let remainder = &self.current_line[truncate_at..];
+                    if let Some(remainder_nonwhite) = remainder
+                        .iter()
+                        .position(|Styled(c, _)| !c.chars().all(&char::is_whitespace))
+                    {
+                        self.next_line
+                            .extend_from_slice(&remainder[remainder_nonwhite..]);
+                    }
+                }
+                self.current_line.truncate(truncate_at);
+                current_line_width = truncated_width;
+                break;
+            }
+
+            prev_whitespace = symbol_whitespace;
+        }
+
+        // Even if the iterator is exhausted, pass the previous remainder.
+        if symbols_exhausted && self.current_line.is_empty() {
+            None
+        } else {
+            Some((&self.current_line[..], current_line_width))
+        }
+    }
+}
+
+/// A state machine that truncates overhanging lines.
+pub struct LineTruncator<'a, 'b> {
+    symbols: &'b mut Iterator<Item = Styled<'a>>,
+    max_line_width: u16,
+    current_line: Vec<Styled<'a>>,
+}
+
+impl<'a, 'b> LineTruncator<'a, 'b> {
+    pub fn new(
+        symbols: &'b mut Iterator<Item = Styled<'a>>,
+        max_line_width: u16,
+    ) -> LineTruncator<'a, 'b> {
+        LineTruncator {
+            symbols,
+            max_line_width,
+            current_line: vec![],
+        }
+    }
+}
+
+impl<'a, 'b> LineComposer<'a> for LineTruncator<'a, 'b> {
+    fn next_line(&mut self) -> Option<(&[Styled<'a>], u16)> {
+        if self.max_line_width == 0 {
+            return None;
+        }
+
+        self.current_line.truncate(0);
+        let mut current_line_width = 0;
+
+        let mut skip_rest = false;
+        let mut symbols_exhausted = true;
+        for Styled(symbol, style) in &mut self.symbols {
+            symbols_exhausted = false;
+
+            // Ignore characters wider that the total max width.
+            if symbol.width() as u16 > self.max_line_width {
+                continue;
+            }
+
+            // Break on newline and discard it.
+            if symbol == "\n" {
+                break;
+            }
+
+            if current_line_width + symbol.width() as u16 > self.max_line_width {
+                // Exhaust the remainder of the line.
+                skip_rest = true;
+                break;
+            }
+
+            current_line_width += symbol.width() as u16;
+            self.current_line.push(Styled(symbol, style));
+        }
+
+        if skip_rest {
+            for Styled(symbol, _) in &mut self.symbols {
+                if symbol == "\n" {
+                    break;
+                }
+            }
+        }
+
+        if symbols_exhausted && self.current_line.is_empty() {
+            None
+        } else {
+            Some((&self.current_line[..], current_line_width))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use unicode_segmentation::UnicodeSegmentation;
+
+    enum Composer {
+        WordWrapper,
+        LineTruncator,
+    }
+
+    fn run_composer(which: Composer, text: &str, text_area_width: u16) -> (Vec<String>, Vec<u16>) {
+        let style = Default::default();
+        let mut styled = UnicodeSegmentation::graphemes(text, true).map(|g| Styled(g, style));
+        let mut composer: Box<dyn LineComposer> = match which {
+            Composer::WordWrapper => Box::new(WordWrapper::new(&mut styled, text_area_width)),
+            Composer::LineTruncator => Box::new(LineTruncator::new(&mut styled, text_area_width)),
+        };
+        let mut lines = vec![];
+        let mut widths = vec![];
+        while let Some((styled, width)) = composer.next_line() {
+            let line = styled
+                .iter()
+                .map(|Styled(g, _style)| *g)
+                .collect::<String>();
+            assert!(width <= text_area_width);
+            lines.push(line);
+            widths.push(width);
+        }
+        (lines, widths)
+    }
+
+    #[test]
+    fn line_composer_one_line() {
+        let width = 40;
+        for i in 1..width {
+            let text = "a".repeat(i);
+            let (word_wrapper, _) = run_composer(Composer::WordWrapper, &text, width as u16);
+            let (line_truncator, _) = run_composer(Composer::LineTruncator, &text, width as u16);
+            let expected = vec![text];
+            assert_eq!(word_wrapper, expected);
+            assert_eq!(line_truncator, expected);
+        }
+    }
+
+    #[test]
+    fn line_composer_short_lines() {
+        let width = 20;
+        let text =
+            "abcdefg\nhijklmno\npabcdefg\nhijklmn\nopabcdefghijk\nlmnopabcd\n\n\nefghijklmno";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+
+        let wrapped: Vec<&str> = text.split('\n').collect();
+        assert_eq!(word_wrapper, wrapped);
+        assert_eq!(line_truncator, wrapped);
+    }
+
+    #[test]
+    fn line_composer_long_word() {
+        let width = 20;
+        let text = "abcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmno";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width as u16);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width as u16);
+
+        let wrapped = vec![
+            &text[..width],
+            &text[width..width * 2],
+            &text[width * 2..width * 3],
+            &text[width * 3..],
+        ];
+        assert_eq!(
+            word_wrapper, wrapped,
+            "WordWrapper should deect the line cannot be broken on word boundary and \
+             break it at line width limit."
+        );
+        assert_eq!(line_truncator, vec![&text[..width]]);
+    }
+
+    #[test]
+    fn line_composer_long_sentence() {
+        let width = 20;
+        let text =
+            "abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab c d e f g h i j k l m n o";
+        let text_multi_space =
+            "abcd efghij    klmnopabcd efgh     ijklmnopabcdefg hijkl mnopab c d e f g h i j k l \
+             m n o";
+        let (word_wrapper_single_space, _) =
+            run_composer(Composer::WordWrapper, text, width as u16);
+        let (word_wrapper_multi_space, _) =
+            run_composer(Composer::WordWrapper, text_multi_space, width as u16);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width as u16);
+
+        let word_wrapped = vec![
+            "abcd efghij",
+            "klmnopabcd efgh",
+            "ijklmnopabcdefg",
+            "hijkl mnopab c d e f",
+            "g h i j k l m n o",
+        ];
+        assert_eq!(word_wrapper_single_space, word_wrapped);
+        assert_eq!(word_wrapper_multi_space, word_wrapped);
+
+        assert_eq!(line_truncator, vec![&text[..width]]);
+    }
+
+    #[test]
+    fn line_composer_zero_width() {
+        let width = 0;
+        let text = "abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab ";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+
+        let expected: Vec<&str> = Vec::new();
+        assert_eq!(word_wrapper, expected);
+        assert_eq!(line_truncator, expected);
+    }
+
+    #[test]
+    fn line_composer_max_line_width_of_1() {
+        let width = 1;
+        let text = "abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab ";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+
+        let expected: Vec<&str> = UnicodeSegmentation::graphemes(text, true)
+            .filter(|g| g.chars().any(|c| !c.is_whitespace()))
+            .collect();
+        assert_eq!(word_wrapper, expected);
+        assert_eq!(line_truncator, vec!["a"]);
+    }
+
+    #[test]
+    fn line_composer_max_line_width_of_1_double_width_characters() {
+        let width = 1;
+        let text = "コンピュータ上で文字を扱う場合、典型的には文字\naaaによる通信を行う場合にその\
+                    両端点では、";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(word_wrapper, vec!["", "a", "a", "a"]);
+        assert_eq!(line_truncator, vec!["", "a"]);
+    }
+
+    /// Tests WordWrapper with words some of which exceed line length and some not.
+    #[test]
+    fn line_composer_word_wrapper_mixed_length() {
+        let width = 20;
+        let text = "abcd efghij klmnopabcdefghijklmnopabcdefghijkl mnopab cdefghi j klmno";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        assert_eq!(
+            word_wrapper,
+            vec![
+                "abcd efghij",
+                "klmnopabcdefghijklmn",
+                "opabcdefghijkl",
+                "mnopab cdefghi j",
+                "klmno",
+            ]
+        )
+    }
+
+    #[test]
+    fn line_composer_double_width_chars() {
+        let width = 20;
+        let text = "コンピュータ上で文字を扱う場合、典型的には文字による通信を行う場合にその両端点\
+                    では、";
+        let (word_wrapper, word_wrapper_width) = run_composer(Composer::WordWrapper, &text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, &text, width);
+        assert_eq!(line_truncator, vec!["コンピュータ上で文字"]);
+        let wrapped = vec![
+            "コンピュータ上で文字",
+            "を扱う場合、典型的に",
+            "は文字による通信を行",
+            "う場合にその両端点で",
+            "は、",
+        ];
+        assert_eq!(word_wrapper, wrapped);
+        assert_eq!(word_wrapper_width, vec![width, width, width, width, 4]);
+    }
+
+    #[test]
+    fn line_composer_leading_whitespace_removal() {
+        let width = 20;
+        let text = "AAAAAAAAAAAAAAAAAAAA    AAA";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAAAAAAA", "AAA",]);
+        assert_eq!(line_truncator, vec!["AAAAAAAAAAAAAAAAAAAA"]);
+    }
+
+    /// Tests truncation of leading whitespace.
+    #[test]
+    fn line_composer_lots_of_spaces() {
+        let width = 20;
+        let text = "                                                                     ";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(word_wrapper, vec![""]);
+        assert_eq!(line_truncator, vec!["                    "]);
+    }
+
+    /// Tests an input starting with a letter, folowed by spaces - some of the behaviour is
+    /// incidental.
+    #[test]
+    fn line_composer_char_plus_lots_of_spaces() {
+        let width = 20;
+        let text = "a                                                                     ";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        let (line_truncator, _) = run_composer(Composer::LineTruncator, text, width);
+        // What's happening below is: the first line gets consumed, trailing spaces discarded,
+        // after 20 of which a word break occurs (probably shouldn't). The second line break
+        // discards all whitespace. The result should probably be vec!["a"] but it doesn't matter
+        // that much.
+        assert_eq!(word_wrapper, vec!["a", ""]);
+        assert_eq!(line_truncator, vec!["a                   "]);
+    }
+
+    #[test]
+    fn line_composer_word_wrapper_double_width_chars_mixed_with_spaces() {
+        let width = 20;
+        // Japanese seems not to use spaces but we should break on spaces anyway... We're using it
+        // to test double-width chars.
+        // You are more than welcome to add word boundary detection based of alterations of
+        // hiragana and katakana...
+        // This happens to also be a test case for mixed width because regular spaces are single width.
+        let text = "コンピュ ータ上で文字を扱う場合、 典型的には文 字による 通信を行 う場合にその両端点では、";
+        let (word_wrapper, word_wrapper_width) = run_composer(Composer::WordWrapper, text, width);
+        assert_eq!(
+            word_wrapper,
+            vec![
+                "コンピュ",
+                "ータ上で文字を扱う場",
+                "合、 典型的には文",
+                "字による 通信を行",
+                "う場合にその両端点で",
+                "は、",
+            ]
+        );
+        // Odd-sized lines have a space in them.
+        assert_eq!(word_wrapper_width, vec![8, 20, 17, 17, 20, 4]);
+    }
+
+    /// Ensure words separated by nbsp are wrapped as if they were a single one.
+    #[test]
+    fn line_composer_word_wrapper_nbsp() {
+        let width = 20;
+        let text = "AAAAAAAAAAAAAAA AAAA\u{00a0}AAA";
+        let (word_wrapper, _) = run_composer(Composer::WordWrapper, text, width);
+        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAA", "AAAA\u{00a0}AAA",]);
+
+        // Ensure that if the character was a regular space, it would be wrapped differently.
+        let text_space = text.replace("\u{00a0}", " ");
+        let (word_wrapper_space, _) = run_composer(Composer::WordWrapper, &text_space, width);
+        assert_eq!(word_wrapper_space, vec!["AAAAAAAAAAAAAAA AAAA", "AAA",]);
+    }
+}

--- a/tests/paragraph.rs
+++ b/tests/paragraph.rs
@@ -1,0 +1,111 @@
+extern crate failure;
+extern crate termion;
+extern crate tui;
+
+use tui::backend::TestBackend;
+use tui::buffer::Buffer;
+use tui::widgets::{Block, Borders, Paragraph, Text, Widget};
+use tui::Terminal;
+
+#[test]
+fn paragraph_render_single_width() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let s = "The library is based on the principle of immediate rendering with intermediate \
+             buffers. This means that at each new frame you should build all widgets that are \
+             supposed to be part of the UI. While providing a great flexibility for rich and \
+             interactive UI, this may introduce overhead for highly dynamic content.";
+
+    terminal
+        .draw(|mut f| {
+            let size = f.size();
+            let text = [Text::raw(s)];
+            Paragraph::new(text.iter())
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(true)
+                .render(&mut f, size);
+        })
+        .unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "┌──────────────────┐",
+        "│The library is bas│",
+        "│ed on the principl│",
+        "│e of immediate ren│",
+        "│dering with interm│",
+        "│ediate buffers. Th│",
+        "│is means that at e│",
+        "│ach new frame you │",
+        "│should build all w│",
+        "└──────────────────┘",
+    ]);
+    assert_eq!(&expected, terminal.backend().buffer());
+}
+
+#[test]
+fn paragraph_render_double_width() {
+    let backend = TestBackend::new(10, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let s = "コンピュータ上で文字を扱う場合、典型的には文字による通信を行う場合にその両端点では、";
+
+    terminal
+        .draw(|mut f| {
+            let size = f.size();
+            let text = [Text::raw(s)];
+            Paragraph::new(text.iter())
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(true)
+                .render(&mut f, size);
+        })
+        .unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        // This is "OK" - these are double-width characters. In terminal each occupies 2 spaces,
+        // which means the buffer contains a Cell with a full grapheme in it, followed by a vacant
+        // one. Here however, we have plain text, so each character is visibly followed by a space.
+        "┌────────┐",
+        "│コ ン ピ ュ │",
+        "│ー タ 上 で │",
+        "│文 字 を 扱 │",
+        "│う 場 合 、 │",
+        "│典 型 的 に │",
+        "│は 文 字 に │",
+        "│よ る 通 信 │",
+        "│を 行 う 場 │",
+        "└────────┘",
+    ]);
+    assert_eq!(&expected, terminal.backend().buffer());
+}
+
+#[test]
+fn paragraph_render_mixed_width() {
+    let backend = TestBackend::new(10, 7);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let s = "aコンピュータ上で文字を扱う場合、";
+
+    terminal
+        .draw(|mut f| {
+            let size = f.size();
+            let text = [Text::raw(s)];
+            Paragraph::new(text.iter())
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(true)
+                .render(&mut f, size);
+        })
+        .unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        // The internal width is 8 so only 4 slots for double-width characters.
+        "┌────────┐",
+        "│aコ ン ピ  │", // Here we have 1 latin character so only 3 double-width ones can fit.
+        "│ュ ー タ 上 │",
+        "│で 文 字 を │",
+        "│扱 う 場 合 │",
+        "│、       │",
+        "└────────┘",
+    ]);
+    assert_eq!(&expected, terminal.backend().buffer());
+}


### PR DESCRIPTION
There's a bunch of things to improve and test cases to add. LineWrapper is also ugly but I'll be making it prettier when I have tests.

The LineComposer trait implementations cannot be iterators because we attempt to be efficient so we only yield slices of the current line which lives only one "iteration".

The changeset doesn't modify the public API, however the behaviour of `.wrap(true)` has been changed to do wrapping on word boundaries. Since I used runtime polymorphism, we could allow users to inject their own wrapping logic but the interface is ugly (consumes and passes Style), so I'd keep it private.

We may want to reintroduce opt-in previous behaviour of wrapping regardless of previous behaviour but this would require to make `.wrap` take an enum.