### PR TITLE
[crossterm] Remove #attr() styling call when compiling on non-unix systems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 *.log
 *.rs.rustfmt
 .gdb_history
+/.idea

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -75,8 +75,11 @@ impl Backend for CrosstermBackend {
             if let Some(color) = cell.style.bg.into() {
                 s = s.on(color)
             }
-            if let Some(attr) = cell.style.modifier.into() {
-                s = s.attr(attr)
+            #[cfg(unix)]
+            {
+                if let Some(attr) = cell.style.modifier.into() {
+                    s = s.attr(attr)
+                }
             }
             s.paint(&self.screen);
         }


### PR DESCRIPTION
The #attr() isn't available on unix systems, and so it fails to compile on windows.

This is pretty difficult to fix upstream, as windows doesn't really support a whole lot of attributes.

A good idea might be to think of this as a quick fix, and I'll open an issue on crossterm, as it does support _some_ attributes, just not many.
So a better solution should be devised, but until then, we should probably just drop attributes.

https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences