### PR TITLE
Add `divider` for `Tabs`

### DIFF
--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -20,7 +20,7 @@ use widgets::{Block, Widget};
 ///     .block(Block::default().title("Tabs").borders(Borders::ALL))
 ///     .titles(&["Tab1", "Tab2", "Tab3", "Tab4"])
 ///     .style(Style::default().fg(Color::White))
-///     .highlight_style(Style::default().fg(Color::Yellow));
+///     .highlight_style(Style::default().fg(Color::Yellow))
 ///     .divider(DOT);
 /// # }
 /// ```

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -113,7 +113,7 @@ where
 
         let mut x = tabs_area.left();
         let titles_length = self.titles.len();
-        let divider_width = self.divider.chars().count() as u16;
+        let divider_width = self.divider.width() as u16;
         for (title, style, last_title) in self.titles.iter().enumerate().map(|(i, t)| {
             let lt = i + 1 == titles_length;
             if i == self.selected {
@@ -131,10 +131,7 @@ where
                 if x >= tabs_area.right() || last_title {
                     break;
                 } else {
-                    buf.get_mut(x, tabs_area.top())
-                        .set_symbol(self.divider)
-                        .set_fg(self.style.fg)
-                        .set_bg(self.style.bg);
+                    buf.set_string(x, tabs_area.top(), self.divider, style);
                     x += divider_width;
                 }
             }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -113,12 +113,14 @@ where
         self.background(&tabs_area, buf, self.style.bg);
 
         let mut x = tabs_area.left();
+        let titles_length = self.titles.len();
         let divider_width = self.divider.chars().count() as u16;
-        for (title, style) in self.titles.iter().enumerate().map(|(i, t)| {
+        for (title, style, last_title) in self.titles.iter().enumerate().map(|(i, t)| {
+            let lt = i + 1 == titles_length;
             if i == self.selected {
-                (t, self.highlight_style)
+                (t, self.highlight_style, lt)
             } else {
-                (t, self.style)
+                (t, self.style, lt)
             }
         }) {
             x += 1;
@@ -127,7 +129,7 @@ where
             } else {
                 buf.set_string(x, tabs_area.top(), title.as_ref(), style);
                 x += title.as_ref().width() as u16 + 1;
-                if x >= tabs_area.right() {
+                if x >= tabs_area.right() || last_title {
                     break;
                 } else {
                     buf.get_mut(x, tabs_area.top())

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -14,12 +14,14 @@ use widgets::{Block, Widget};
 /// # extern crate tui;
 /// # use tui::widgets::{Block, Borders, Tabs};
 /// # use tui::style::{Style, Color};
+/// # use tui::symbols::{DOT};
 /// # fn main() {
 /// Tabs::default()
 ///     .block(Block::default().title("Tabs").borders(Borders::ALL))
 ///     .titles(&["Tab1", "Tab2", "Tab3", "Tab4"])
 ///     .style(Style::default().fg(Color::White))
 ///     .highlight_style(Style::default().fg(Color::Yellow));
+///     .divider(DOT);
 /// # }
 /// ```
 pub struct Tabs<'a, T>
@@ -36,6 +38,8 @@ where
     style: Style,
     /// The style used to display the selected item
     highlight_style: Style,
+    /// Tab divider
+    divider: &'a str,
 }
 
 impl<'a, T> Default for Tabs<'a, T>
@@ -49,6 +53,7 @@ where
             selected: 0,
             style: Default::default(),
             highlight_style: Default::default(),
+            divider: line::VERTICAL,
         }
     }
 }
@@ -81,6 +86,11 @@ where
         self.highlight_style = style;
         self
     }
+
+    pub fn divider(mut self, divider: &'a str) -> Tabs<'a, T> {
+        self.divider = divider;
+        self
+    }
 }
 
 impl<'a, T> Widget for Tabs<'a, T>
@@ -103,6 +113,7 @@ where
         self.background(&tabs_area, buf, self.style.bg);
 
         let mut x = tabs_area.left();
+        let divider_width = self.divider.chars().count() as u16;
         for (title, style) in self.titles.iter().enumerate().map(|(i, t)| {
             if i == self.selected {
                 (t, self.highlight_style)
@@ -120,10 +131,10 @@ where
                     break;
                 } else {
                     buf.get_mut(x, tabs_area.top())
-                        .set_symbol(line::VERTICAL)
+                        .set_symbol(self.divider)
                         .set_fg(self.style.fg)
                         .set_bg(self.style.bg);
-                    x += 1;
+                    x += divider_width;
                 }
             }
         }


### PR DESCRIPTION
and don't show divider after last tab.

**_Short reminder:_** Before this PR we had the following:

![screenshot from 2019-01-09 19-34-22](https://user-images.githubusercontent.com/47693/50920446-b4cacf80-1445-11e9-9c30-a8ec3fb3f5a1.png)

Now we can do something like the following examples...

## Examples

### `|` `tui::symbols::line::VERTICAL` as default divider (same as before) 

```rs
 Tabs::default()
     .block(Block::default().title("Tabs").borders(Borders::ALL))
     .titles(&["Tab0", "Tab1", "Tab2", "Tab3"])
     .style(Style::default().fg(Color::White))
     .highlight_style(Style::default().fg(Color::Yellow));
```

![screenshot from 2019-01-09 18-38-30](https://user-images.githubusercontent.com/47693/50919289-b21aab00-1442-11e9-9ba0-b9cc2bba9dbf.png)


### `•` divider by using `tui::symbols::DOT`

```rs
 Tabs::default()
     .block(Block::default().title("Tabs").borders(Borders::ALL))
     .titles(&["Tab0", "Tab1", "Tab2", "Tab3"])
     .style(Style::default().fg(Color::White))
     .highlight_style(Style::default().fg(Color::Yellow));
     .divider(DOT);
```

![screenshot from 2019-01-09 18-38-00](https://user-images.githubusercontent.com/47693/50919273-a62ee900-1442-11e9-84b3-d526db47d22c.png)

### `~` (custom) divider

```rs
 Tabs::default()
     .block(Block::default().title("Tabs").borders(Borders::ALL))
     .titles(&["Tab0", "Tab1", "Tab2", "Tab3"])
     .style(Style::default().fg(Color::White))
     .highlight_style(Style::default().fg(Color::Yellow));
     .divider("~");
```

![screenshot from 2019-01-09 18-39-24](https://user-images.githubusercontent.com/47693/50919404-045bcc00-1443-11e9-9d7d-aa18610a7eb9.png)

### `//` (custom) divider 
```rs
 Tabs::default()
     .block(Block::default().title("Tabs").borders(Borders::ALL))
     .titles(&["Tab0", "Tab1", "Tab2", "Tab3"])
     .style(Style::default().fg(Color::White))
     .highlight_style(Style::default().fg(Color::Yellow));
     .divider("//");
```
![screenshot from 2019-01-09 18-48-21](https://user-images.githubusercontent.com/47693/50919457-26ede500-1443-11e9-8871-bc5840918a3c.png)

### `.::.` (custom) divider
```rs
 Tabs::default()
     .block(Block::default().title("Tabs").borders(Borders::ALL))
     .titles(&["Tab0", "Tab1", "Tab2", "Tab3"])
     .style(Style::default().fg(Color::White))
     .highlight_style(Style::default().fg(Color::Yellow));
     .divider(".::.");
```
![screenshot from 2019-01-09 18-49-13](https://user-images.githubusercontent.com/47693/50919481-33723d80-1443-11e9-8fae-e9aaff8177bc.png)

### `|***|` (custom) divider
```rs
 Tabs::default()
     .block(Block::default().title("Tabs").borders(Borders::ALL))
     .titles(&["Tab0", "Tab1", "Tab2", "Tab3"])
     .style(Style::default().fg(Color::White))
     .highlight_style(Style::default().fg(Color::Yellow));
     .divider("|***|");
```
![screenshot from 2019-01-09 18-53-26](https://user-images.githubusercontent.com/47693/50919500-4422b380-1443-11e9-93eb-a0050e95b486.png)

### Note: Last title won't show a divider anymore, so that a tab list with just one element looks like the following. 
![screenshot from 2019-01-09 19-01-34](https://user-images.githubusercontent.com/47693/50919517-50a70c00-1443-11e9-9f9b-6b00ee75b61f.png)
At a first glance tabs with one element might not make sense... However, in some cases you might have just one element by creating tabs from "unknown" sources (with an unknown number of elements).



