### PR TITLE
Create Crossterm Backend with Previously Created Screen

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -16,6 +16,10 @@ impl CrosstermBackend {
         }
     }
 
+    pub fn with_crossterm(scr: crossterm::Screen) -> CrosstermBackend {
+        CrosstermBackend { screen: scr }
+    }
+
     pub fn screen(&self) -> &crossterm::Screen {
         &self.screen
     }

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -16,8 +16,8 @@ impl CrosstermBackend {
         }
     }
 
-    pub fn with_crossterm(scr: crossterm::Screen) -> CrosstermBackend {
-        CrosstermBackend { screen: scr }
+    pub fn with_screen(screen: crossterm::Screen) -> CrosstermBackend {
+        CrosstermBackend { screen: screen }
     }
 
     pub fn screen(&self) -> &crossterm::Screen {


### PR DESCRIPTION
Added the ability to create the crossterm backend with a previously created screen. This will allow the API user to specify whether they want to enter into raw mode and perform any prior setup on the crossterm end before passing off to tui.