### PR TITLE
Add alternate screen mode to crossterm backend

### DIFF
--- a/examples/crossterm_demo.rs
+++ b/examples/crossterm_demo.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 use tui::backend::CrosstermBackend;
 use tui::Terminal;
+use crossterm;
 
 use crate::demo::{ui, App};
 
@@ -30,7 +31,9 @@ fn main() -> Result<(), failure::Error> {
     let cli = Cli::from_args();
     stderrlog::new().quiet(!cli.log).verbosity(4).init()?;
 
-    let backend = CrosstermBackend::new();
+    let screen = crossterm::Screen::default();
+    let alternate_screen = screen.enable_alternate_modes(true)?;
+    let backend = CrosstermBackend::with_alternate_screen(alternate_screen)?;
     let mut terminal = Terminal::new(backend)?;
     terminal.hide_cursor()?;
 

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -7,7 +7,7 @@ use crate::style::{Color, Modifier};
 use crossterm::error::ErrorKind;
 
 pub struct CrosstermBackend {
-    screen: crossterm::Screen,
+    screen: Option<crossterm::Screen>,
     crossterm: crossterm::Crossterm,
     // Need to keep the AlternateScreen around even when not using it directly,
     // see https://github.com/TimonPost/crossterm/issues/88
@@ -19,7 +19,7 @@ impl Default for CrosstermBackend {
         let screen = crossterm::Screen::default();
         let crossterm = crossterm::Crossterm::from_screen(&screen);
         CrosstermBackend {
-            screen,
+            screen: Some(screen),
             crossterm,
             alternate_screen: None,
         }
@@ -34,24 +34,26 @@ impl CrosstermBackend {
     pub fn with_screen(screen: crossterm::Screen) -> CrosstermBackend {
         let crossterm = crossterm::Crossterm::from_screen(&screen);
         CrosstermBackend {
-            screen,
+            screen: Some(screen),
             crossterm,
             alternate_screen: None,
         }
     }
 
-    pub fn with_alternate_screen(screen: crossterm::Screen, raw_mode: bool) -> Result<CrosstermBackend, io::Error> {
-        let alternate_screen = screen.enable_alternate_modes(raw_mode)?;
+    pub fn with_alternate_screen(alternate_screen: crossterm::AlternateScreen) -> Result<CrosstermBackend, io::Error> {
         let crossterm = crossterm::Crossterm::from_screen(&alternate_screen.screen);
         Ok(CrosstermBackend {
-            screen,
+            screen: None,
             crossterm,
             alternate_screen: Some(alternate_screen),
         })
     }
 
-    pub fn screen(&self) -> &crossterm::Screen {
-        &self.screen
+    pub fn screen(&self) -> Option<&crossterm::Screen> {
+        match &self.screen {
+            Some(screen) => Some(&screen),
+            None => None,
+        }
     }
 
     pub fn alternate_screen(&self) -> Option<&crossterm::AlternateScreen> {

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -8,12 +8,20 @@ use crossterm::error::ErrorKind;
 
 pub struct CrosstermBackend {
     screen: crossterm::Screen,
+    crossterm: crossterm::Crossterm,
+    // Need to keep the AlternateScreen around even when not using it directly,
+    // see https://github.com/TimonPost/crossterm/issues/88
+    alternate_screen: Option<crossterm::AlternateScreen>,
 }
 
 impl Default for CrosstermBackend {
     fn default() -> CrosstermBackend {
+        let screen = crossterm::Screen::default();
+        let crossterm = crossterm::Crossterm::from_screen(&screen);
         CrosstermBackend {
-            screen: crossterm::Screen::default(),
+            screen,
+            crossterm,
+            alternate_screen: None,
         }
     }
 }
@@ -24,11 +32,37 @@ impl CrosstermBackend {
     }
 
     pub fn with_screen(screen: crossterm::Screen) -> CrosstermBackend {
-        CrosstermBackend { screen: screen }
+        let crossterm = crossterm::Crossterm::from_screen(&screen);
+        CrosstermBackend {
+            screen,
+            crossterm,
+            alternate_screen: None,
+        }
+    }
+
+    pub fn with_alternate_screen(screen: crossterm::Screen, raw_mode: bool) -> Result<CrosstermBackend, io::Error> {
+        let alternate_screen = screen.enable_alternate_modes(raw_mode)?;
+        let crossterm = crossterm::Crossterm::from_screen(&alternate_screen.screen);
+        Ok(CrosstermBackend {
+            screen,
+            crossterm,
+            alternate_screen: Some(alternate_screen),
+        })
     }
 
     pub fn screen(&self) -> &crossterm::Screen {
         &self.screen
+    }
+
+    pub fn alternate_screen(&self) -> Option<&crossterm::AlternateScreen> {
+        match &self.alternate_screen {
+            Some(alt_screen) => Some(&alt_screen),
+            None => None,
+        }
+    }
+
+    pub fn crossterm(&self) -> &crossterm::Crossterm {
+        &self.crossterm
     }
 }
 
@@ -50,7 +84,7 @@ fn convert_error(error: ErrorKind) -> io::Error {
 
 impl Backend for CrosstermBackend {
     fn clear(&mut self) -> io::Result<()> {
-        let terminal = crossterm::terminal();
+        let terminal = self.crossterm.terminal();
         terminal
             .clear(crossterm::ClearType::All)
             .map_err(convert_error)?;
@@ -58,19 +92,19 @@ impl Backend for CrosstermBackend {
     }
 
     fn hide_cursor(&mut self) -> io::Result<()> {
-        let cursor = crossterm::cursor();
+        let cursor = self.crossterm.cursor();
         cursor.hide().map_err(convert_error)?;
         Ok(())
     }
 
     fn show_cursor(&mut self) -> io::Result<()> {
-        let cursor = crossterm::cursor();
+        let cursor = self.crossterm.cursor();
         cursor.show().map_err(convert_error)?;
         Ok(())
     }
 
     fn size(&self) -> io::Result<Rect> {
-        let terminal = crossterm::terminal();
+        let terminal = self.crossterm.terminal();
         let (width, height) = terminal.terminal_size();
         Ok(Rect::new(0, 0, width, height))
     }
@@ -83,8 +117,7 @@ impl Backend for CrosstermBackend {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
-        let cursor = crossterm::cursor();
-        let crossterm = crossterm::Crossterm::from_screen(&self.screen);
+        let cursor = self.crossterm.cursor();
         let mut last_y = 0;
         let mut last_x = 0;
         let mut first = true;
@@ -95,8 +128,7 @@ impl Backend for CrosstermBackend {
             }
             last_x = x;
             last_y = y;
-
-            let mut s = crossterm::style(&cell.symbol);
+            let mut s = self.crossterm.style(&cell.symbol);
             if let Some(color) = cell.style.fg.into() {
                 s = s.with(color)
             }
@@ -106,7 +138,7 @@ impl Backend for CrosstermBackend {
             if let Some(attr) = cell.style.modifier.into() {
                 s = s.attr(attr)
             }
-            crossterm.paint(s).map_err(convert_error)?;
+            self.crossterm.paint(s).map_err(convert_error)?;
         }
         Ok(())
     }


### PR DESCRIPTION
`CrosstermBackend` currently does not allow alternate screen mode where we return to the original screen once we're done. #125 doesn't seem to fix this because we can't move a screen out of [AlternateScreen](https://docs.rs/crossterm/0.6.0/crossterm/struct.AlternateScreen.html) because of `Drop` (see [this](https://github.com/TimonPost/crossterm/issues/74) crossterm issue). This PR adds the required methods to `CrosstermBackend` and adds `crossterm_demo.rs` as an example.