### PR TITLE
Relaxing crossterm dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ appveyor = { repository = "fdehau/tui-rs" }
 [features]
 default = ["termion"]
 curses = ["easycurses", "pancurses"]
-crossterm_backend = ["crossterm"]
 
 [dependencies]
 bitflags = "1.0"
@@ -31,7 +30,7 @@ unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
 rustbox = { version = "0.11", optional = true }
-crossterm = { version = "0.9.4", optional = true }
+crossterm = { version = "^0.9", optional = true }
 easycurses = { version = "0.12.2", optional = true }
 pancurses = { version = "0.16.1", optional = true, features = ["win32a"] }
 


### PR DESCRIPTION
This is a follow-up to #153.

Since `crossterm 0.9` version development is still in progress (as an example, see [this bug](https://github.com/TimonPost/crossterm/issues/141)), forcing to use one specific version is a little bit excessive, so this PR relaxes `crossterm` version to `^0.9`.
@TimonPost confirmed that `crossterm` adheres to semantic versioning, therefore version can be relaxed safely.

As an addition, I removed the `crossterm_backend` feature because of two reasons:
 1. `crossterm` feature is exists already (because `crossterm` as a depedency is optional)
 2. Code that introduces it was merged into master 6 hours ago (at the time of creating this PR) and was not published yet, therefore possibility of breaking something is really small.

P.S. I have personal request also - can there be new version of `tui` published after merge of this PR? This is a only thing which [blocks](https://github.com/svartalf/rust-battop/issues/5) me.