### PR TITLE
Provide Clone and Debug for Text type

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -47,6 +47,7 @@ bitflags! {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum Text<'b> {
     Raw(Cow<'b, str>),
     Styled(Cow<'b, str>, Style),


### PR DESCRIPTION
I know using clone isn't the best practice, but in some cases it can be extremely convenient. I'm working on a project where I'm doing quite a dance to get around it. In the end I wondered why I wasn't using clone and the answer wasn't obvious.

Am currently using a local fork with this in the meantime.