### PR TITLE
Don't highlight Tabs divider after selection

### DIFF
--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -131,7 +131,7 @@ where
                 if x >= tabs_area.right() || last_title {
                     break;
                 } else {
-                    buf.set_string(x, tabs_area.top(), self.divider, style);
+                    buf.set_string(x, tabs_area.top(), self.divider, self.style);
                     x += divider_width;
                 }
             }


### PR DESCRIPTION
This PR fixes the highlight behavior of `Tabs`. Currently the divider after the current selection is highlighted as well as the selection, which seems unintended to me. Feel free to close if it's not.

Before:
![2019-05-29-202755_351x57_scrot](https://user-images.githubusercontent.com/7799664/58606441-49e13000-8250-11e9-842a-b11051bbd048.png)

After:
![2019-05-29-202733_360x53_scrot](https://user-images.githubusercontent.com/7799664/58606443-4e0d4d80-8250-11e9-84fb-d0992b6dfcd3.png)



