### PR TITLE
Allow rendering for those who do not implement `Widget`

### DIFF
--- a/examples/stateful_component.rs
+++ b/examples/stateful_component.rs
@@ -1,0 +1,189 @@
+#[allow(dead_code)]
+mod util;
+
+use std::io;
+
+use termion::event::Key;
+use termion::input::MouseTerminal;
+use termion::raw::IntoRawMode;
+use termion::screen::AlternateScreen;
+use tui::{backend::TermionBackend, Terminal};
+
+use crate::util::event::{Event, Events};
+use tui::style::{Color, Style};
+use tui::widgets::Text;
+
+/// This list does not implement widget, but instead provides a render call taking properties.
+/// On top of that, it can keep its own state, which can conveniently be accessible to the parent application
+/// to control it. However, the component is able to write its own state and adjust it based on information
+/// it only obtains when drawing.
+///
+/// If this seems a little like React, you might be right!
+mod list {
+    use tui::{
+        buffer::Buffer,
+        layout::Rect,
+        widgets::{Block, Paragraph, Text, Widget},
+    };
+
+    /// Thanks to the state maintained in this list, it can scroll naturally.
+    /// Compare this to the `List` `Widget` in TUI, which seems to 'stick to the bottom'.
+    #[derive(Default)]
+    pub struct StatefulList {
+        /// The index at which the list last started. Used for scrolling
+        offset: usize,
+    }
+
+    #[derive(Default)]
+    pub struct StatefulListProps<'b> {
+        pub block: Option<Block<'b>>,
+        pub entry_in_view: Option<usize>,
+    }
+
+    impl StatefulList {
+        fn list_offset_for(&self, entry_in_view: Option<usize>, height: usize) -> usize {
+            match entry_in_view {
+                Some(pos) => match height as usize {
+                    h if self.offset + h - 1 < pos => pos - h + 1,
+                    _ if self.offset > pos => pos,
+                    _ => self.offset,
+                },
+                None => 0,
+            }
+        }
+    }
+
+    impl StatefulList {
+        pub fn render<'a, 't>(
+            &mut self,
+            props: StatefulListProps<'a>,
+            items: impl IntoIterator<Item = Vec<Text<'t>>>,
+            area: Rect,
+            buf: &mut Buffer,
+        ) {
+            let StatefulListProps {
+                block,
+                entry_in_view,
+            } = props;
+
+            let list_area = match block {
+                Some(mut b) => {
+                    b.draw(area, buf);
+                    b.inner(area)
+                }
+                None => area,
+            };
+            // Here is the magic - we mutate our own state to automatically handle proper scrolling.
+            // The same can be accomplished with stateless components, but then the caller has to know
+            // and maintain all of its state somewhere.
+            // Bringing the state to where it is 'owned' is very convenient.
+            self.offset = self.list_offset_for(entry_in_view, list_area.height as usize);
+
+            if list_area.width < 1 || list_area.height < 1 {
+                return;
+            }
+
+            for (i, text_iterator) in items
+                .into_iter()
+                .skip(self.offset)
+                .enumerate()
+                .take(list_area.height as usize)
+            {
+                let (x, y) = (list_area.left(), list_area.top() + i as u16);
+                Paragraph::new(text_iterator.iter()).draw(
+                    Rect {
+                        x,
+                        y,
+                        width: list_area.width,
+                        height: 1,
+                    },
+                    buf,
+                );
+            }
+        }
+    }
+}
+
+fn main() -> Result<(), failure::Error> {
+    // Terminal initialization
+    let stdout = io::stdout().into_raw_mode()?;
+    let stdout = MouseTerminal::from(stdout);
+    let stdout = AlternateScreen::from(stdout);
+    let backend = TermionBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let events = Events::new();
+
+    let mut list = list::StatefulList::default();
+    let mut selected = 0;
+
+    terminal.hide_cursor()?;
+    let labels = [
+        "j or <down> for going down",
+        "k or <up> for going up",
+        "Ctrl + u for going up fast",
+        "Ctrl + d for going down fast",
+        "foo",
+        "bar",
+        "baz",
+        "yes",
+        "no",
+        "maybe",
+        "great",
+        "awesome",
+        "fantastic!",
+    ];
+    const NUM_ENTRIES: usize = 200;
+    loop {
+        let area = terminal.pre_draw()?;
+        let props = list::StatefulListProps {
+            block: None,
+            entry_in_view: Some(selected),
+        };
+        let entries = (0..NUM_ENTRIES).map(|idx| {
+            let (fg, bg) = if idx == selected {
+                (Color::Yellow, Color::Blue)
+            } else {
+                (Color::White, Color::Reset)
+            };
+            vec![
+                Text::Styled(
+                    format!(" {:>3}. ", idx + 1).into(),
+                    Style {
+                        fg: Color::Red,
+                        bg,
+                        ..Default::default()
+                    },
+                ),
+                Text::Styled(
+                    labels[idx % labels.len()].into(),
+                    Style {
+                        fg,
+                        bg,
+                        ..Default::default()
+                    },
+                ),
+            ]
+        });
+        list.render(props, entries, area, terminal.current_buffer_mut());
+        terminal.post_draw()?;
+
+        use Key::*;
+        match events.next()? {
+            Event::Input(key) => {
+                selected = match key {
+                    Char('j') | Down => selected.saturating_add(1),
+                    Ctrl('d') | PageDown => selected.saturating_add(10),
+                    Char('k') | Up => selected.saturating_sub(1),
+                    Ctrl('u') | PageUp => selected.saturating_sub(10),
+                    Char('q') => break,
+                    _ => selected,
+                }
+                .min(NUM_ENTRIES - 1)
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -29,7 +29,7 @@ use crate::layout::Rect;
 use crate::style::{Color, Style};
 use crate::terminal::Frame;
 
-/// Bitflags that can be composed to set the visible borders essentially on the block widget.
+// Bitflags that can be composed to set the visible borders essentially on the block widget.
 bitflags! {
     pub struct Borders: u32 {
         /// Show no border (default)


### PR DESCRIPTION
This minor and non-breaking change to `Terminal` enables stateful components, which I found most useful during my work on the [`disk usage analyzer`](https://github.com/Byron/dua-cli).

An example is provided, implementing a list that scrolls the way one would expect it.

During my development, I tried a lot to workaround the limitations imposed by having to use Widget, which made it hard to use stateful components. It felt 'off' and I couldn't keep going like this.

It showed that not relying on any trait opens up the whole system to any use one would want to have, including a more _React'ish_ approach which feels much more natural. And thanks to Rust, it's absolutely safe to do.

I hope you like the example, please let me know your thoughts and possibly change requests.

_PS_: For now I have created https://crates.io/crates/tui-react to keep my changes, but I realized it would be better to have some of them merged here and to find a way to contribute 'non-standard' components back to this project. I am thinking something along the lines of [`Rocket-Contrib`](https://github.com/SergioBenitez/Rocket/tree/master/contrib/lib). However, this might be off-topic here.