### PR TITLE
fix for canvas rendering edge cases causing overflow errors

### DIFF
--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -99,7 +99,7 @@ impl<'a> Context<'a> {
         let top = self.y_bounds[1];
         for (x, y) in shape
             .points()
-            .filter(|&(x, y)| !(x < left || x > right || y < bottom || y > top))
+            .filter(|&(x, y)| !(x <= left || x >= right || y <= bottom || y >= top))
         {
             let dy = ((top - y) * f64::from(self.height - 1) * 4.0 / (top - bottom)) as usize;
             let dx = ((x - left) * f64::from(self.width - 1) * 2.0 / (right - left)) as usize;

--- a/tests/chart.rs
+++ b/tests/chart.rs
@@ -1,0 +1,37 @@
+use tui::backend::TestBackend;
+use tui::layout::Rect;
+use tui::style::{Color, Style};
+use tui::widgets::{Axis, Block, Borders, Chart, Dataset, Marker, Widget};
+use tui::Terminal;
+
+#[test]
+fn zero_axes_ok() {
+    let backend = TestBackend::new(100, 100);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|mut f| {
+        Chart::default()
+            .block(Block::default().title("Plot").borders(Borders::ALL))
+            .x_axis(
+                Axis::default()
+                    .bounds([ 0.0, 0.0, ])
+                    .labels(&["0.0", "1.0"])
+            )
+            .y_axis(
+                Axis::default()
+                    .bounds([ 0.0, 1.0, ])
+                    .labels(&["0.0", "1.0"])
+            )
+            .datasets(&[Dataset::default()
+                .marker(Marker::Braille)
+                .style(Style::default().fg(Color::Magenta))
+                .data(&[(0.0, 0.0)])])
+            .render(&mut f, Rect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            });
+        }).unwrap();
+}


### PR DESCRIPTION
In certain edge cases (like the test case provided in `tests/chart.rs`) a canvas can cause a panic. This change tests for this edge case and includes a regression test for the future.