### PR TITLE
[Draft] Add alignment options for the table widget

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -435,46 +435,52 @@ impl Rect {
     }
 }
 
-#[test]
-fn test_rect_size_truncation() {
-    for width in 256u16..300u16 {
-        for height in 256u16..300u16 {
-            let rect = Rect::new(0, 0, width, height);
-            rect.area(); // Should not panic.
-            assert!(rect.width < width || rect.height < height);
-            // The target dimensions are rounded down so the math will not be too precise
-            // but let's make sure the ratios don't diverge crazily.
-            assert!(
-                (f64::from(rect.width) / f64::from(rect.height)
-                    - f64::from(width) / f64::from(height))
-                .abs()
-                    < 1.0
-            )
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rect_size_truncation() {
+        for width in 256u16..300u16 {
+            for height in 256u16..300u16 {
+                let rect = Rect::new(0, 0, width, height);
+                rect.area(); // Should not panic.
+                assert!(rect.width < width || rect.height < height);
+                // The target dimensions are rounded down so the math will not be too precise
+                // but let's make sure the ratios don't diverge crazily.
+                assert!(
+                    (f64::from(rect.width) / f64::from(rect.height)
+                        - f64::from(width) / f64::from(height))
+                    .abs()
+                        < 1.0
+                )
+            }
         }
+
+        // One dimension below 255, one above. Area above max u16.
+        let width = 900;
+        let height = 100;
+        let rect = Rect::new(0, 0, width, height);
+        assert_ne!(rect.width, 900);
+        assert_ne!(rect.height, 100);
+        assert!(rect.width < width || rect.height < height);
     }
 
-    // One dimension below 255, one above. Area above max u16.
-    let width = 900;
-    let height = 100;
-    let rect = Rect::new(0, 0, width, height);
-    assert_ne!(rect.width, 900);
-    assert_ne!(rect.height, 100);
-    assert!(rect.width < width || rect.height < height);
-}
-
-#[test]
-fn test_rect_size_preservation() {
-    for width in 0..256u16 {
-        for height in 0..256u16 {
-            let rect = Rect::new(0, 0, width, height);
-            rect.area(); // Should not panic.
-            assert_eq!(rect.width, width);
-            assert_eq!(rect.height, height);
+    #[test]
+    fn test_rect_size_preservation() {
+        for width in 0..256u16 {
+            for height in 0..256u16 {
+                let rect = Rect::new(0, 0, width, height);
+                rect.area(); // Should not panic.
+                assert_eq!(rect.width, width);
+                assert_eq!(rect.height, height);
+            }
         }
+
+        // One dimension below 255, one above. Area below max u16.
+        let rect = Rect::new(0, 0, 300, 100);
+        assert_eq!(rect.width, 300);
+        assert_eq!(rect.height, 100);
     }
 
-    // One dimension below 255, one above. Area below max u16.
-    let rect = Rect::new(0, 0, 300, 100);
-    assert_eq!(rect.width, 300);
-    assert_eq!(rect.height, 100);
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -37,6 +37,16 @@ pub enum Alignment {
     Right,
 }
 
+/// Get the offset position for a line to display it at a set alignment given the width of the line
+/// and the width of its container
+pub fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) -> u16 {
+    match alignment {
+        Alignment::Center => (text_area_width / 2).saturating_sub(line_width / 2),
+        Alignment::Right => text_area_width.saturating_sub(line_width),
+        Alignment::Left => 0,
+    }
+}
+
 // TODO: enforce constraints size once const generics has landed
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Layout {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -483,4 +483,46 @@ mod tests {
         assert_eq!(rect.height, 100);
     }
 
+    #[test]
+    fn test_get_line_offset() {
+        // empty string in empty container
+        assert_eq!(get_line_offset(0, 0, Alignment::Left), 0);
+        assert_eq!(get_line_offset(0, 0, Alignment::Center), 0);
+        assert_eq!(get_line_offset(0, 0, Alignment::Right), 0);
+
+        // empty string in sized container
+        assert_eq!(get_line_offset(0, 10, Alignment::Left), 0);
+        assert_eq!(get_line_offset(0, 10, Alignment::Center), 5);
+        assert_eq!(get_line_offset(0, 10, Alignment::Right), 10);
+
+        // string same size as container
+        assert_eq!(get_line_offset(10, 10, Alignment::Left), 0);
+        assert_eq!(get_line_offset(10, 10, Alignment::Center), 0);
+        assert_eq!(get_line_offset(10, 10, Alignment::Right), 0);
+
+        // 1 char string in even sized container
+        assert_eq!(get_line_offset(1, 10, Alignment::Left), 0);
+        assert_eq!(get_line_offset(1, 10, Alignment::Center), 5);
+        assert_eq!(get_line_offset(1, 10, Alignment::Right), 9);
+
+        // 2 char string in even sized container
+        assert_eq!(get_line_offset(2, 10, Alignment::Left), 0);
+        assert_eq!(get_line_offset(2, 10, Alignment::Center), 4);
+        assert_eq!(get_line_offset(2, 10, Alignment::Right), 8);
+
+        // 1 char string in odd sized container
+        assert_eq!(get_line_offset(1, 9, Alignment::Left), 0);
+        assert_eq!(get_line_offset(1, 9, Alignment::Center), 4);
+        assert_eq!(get_line_offset(1, 9, Alignment::Right), 8);
+
+        // 2 char string in odd sized container
+        assert_eq!(get_line_offset(2, 9, Alignment::Left), 0);
+        assert_eq!(get_line_offset(2, 9, Alignment::Center), 3);
+        assert_eq!(get_line_offset(2, 9, Alignment::Right), 7);
+
+        // string longer than container
+        assert_eq!(get_line_offset(10, 0, Alignment::Left), 0);
+        assert_eq!(get_line_offset(10, 0, Alignment::Center), 0);
+        assert_eq!(get_line_offset(10, 0, Alignment::Right), 0);
+    }
 }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -3,18 +3,11 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::buffer::Buffer;
+use crate::layout;
 use crate::layout::{Alignment, Rect};
 use crate::style::Style;
 use crate::widgets::reflow::{LineComposer, LineTruncator, Styled, WordWrapper};
 use crate::widgets::{Block, Text, Widget};
-
-fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) -> u16 {
-    match alignment {
-        Alignment::Center => (text_area_width / 2).saturating_sub(line_width / 2),
-        Alignment::Right => text_area_width.saturating_sub(line_width),
-        Alignment::Left => 0,
-    }
-}
 
 /// A widget to display some text.
 ///
@@ -142,7 +135,8 @@ where
         let mut y = 0;
         while let Some((current_line, current_line_width)) = line_composer.next_line() {
             if y >= self.scroll {
-                let mut x = get_line_offset(current_line_width, text_area.width, self.alignment);
+                let mut x =
+                    layout::get_line_offset(current_line_width, text_area.width, self.alignment);
                 for Styled(symbol, style) in current_line {
                     buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll)
                         .set_symbol(symbol)

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -64,6 +64,10 @@ where
     column_spacing: u16,
     /// Data to display in each row
     rows: R,
+    /// Alignment of header text
+    header_alignment: &'a [Alignment],
+    /// Alignment of body columns
+    alignment: &'a [Alignment],
 }
 
 impl<'a, T, H, I, D, R> Default for Table<'a, T, H, I, D, R>
@@ -83,6 +87,8 @@ where
             widths: &[],
             rows: R::default(),
             column_spacing: 1,
+            header_alignment: &[],
+            alignment: &[],
         }
     }
 }
@@ -104,6 +110,8 @@ where
             widths: &[],
             rows,
             column_spacing: 1,
+            header_alignment: &[],
+            alignment: &[],
         }
     }
     pub fn block(mut self, block: Block<'a>) -> Table<'a, T, H, I, D, R> {
@@ -144,6 +152,16 @@ where
 
     pub fn column_spacing(mut self, spacing: u16) -> Table<'a, T, H, I, D, R> {
         self.column_spacing = spacing;
+        self
+    }
+
+    pub fn header_alignment(mut self, alignments: &'a [Alignment]) -> Table<'a, T, H, I, D, R> {
+        self.header_alignment = alignments;
+        self
+    }
+
+    pub fn alignment(mut self, alignments: &'a [Alignment]) -> Table<'a, T, H, I, D, R> {
+        self.alignment = alignments;
         self
     }
 }


### PR DESCRIPTION
This provides two new methods which allow use of alignments for the header columns and body columns: `header_alignment` and `alignment`.

They make use of the `layout::Alignment` enum for consistency.

When drawing, if the alignment has not been set for a column then it is assumed to be Left.

This is WIP until the initial testing additions from #170 are added or via some other way. This should also fix the formatting issue in `tests/chart.rs`.