### PR TITLE
Update docs to point to latest version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tui = "0.5"
+//! tui = "0.6"
 //! termion = "1.5"
 //! ```
 //!
@@ -21,7 +21,7 @@
 //! rustbox = "0.11"
 //!
 //! [dependencies.tui]
-//! version = "0.5"
+//! version = "0.6"
 //! default-features = false
 //! features = ['rustbox']
 //! ```


### PR DESCRIPTION
The usage instructions currently tell users to install `0.5` while `0.6` is the latest version. This fixes that