### PR TITLE
Rounded corners and Double line borders

### DIFF
--- a/examples/block.rs
+++ b/examples/block.rs
@@ -9,7 +9,7 @@ use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
 use tui::layout::{Constraint, Direction, Layout};
 use tui::style::{Color, Modifier, Style};
-use tui::widgets::{Block, Borders, Widget};
+use tui::widgets::{Block, BorderType, Borders, Widget};
 use tui::Terminal;
 
 use crate::util::event::{Event, Events};
@@ -35,7 +35,7 @@ fn main() -> Result<(), failure::Error> {
             Block::default()
                 .borders(Borders::ALL)
                 .title("Main block with round corners")
-                .rounded()
+                .set_border_type(BorderType::Rounded)
                 .render(&mut f, size);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -75,7 +75,7 @@ fn main() -> Result<(), failure::Error> {
                     .title("With styled and double borders")
                     .border_style(Style::default().fg(Color::Cyan))
                     .borders(Borders::LEFT | Borders::RIGHT)
-                    .double_border()
+                    .set_border_type(BorderType::Double)
                     .render(&mut f, chunks[1]);
             }
         })?;

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -32,7 +32,11 @@ fn main() -> Result<(), failure::Error> {
             // Just draw the block and the group on the same area and build the group
             // with at least a margin of 1
             let size = f.size();
-            Block::default().borders(Borders::ALL).render(&mut f, size);
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Main block with round corners")
+                .rounded()
+                .render(&mut f, size);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(4)
@@ -68,9 +72,10 @@ fn main() -> Result<(), failure::Error> {
                     .borders(Borders::ALL)
                     .render(&mut f, chunks[0]);
                 Block::default()
-                    .title("With styled borders")
+                    .title("With styled and double borders")
                     .border_style(Style::default().fg(Color::Cyan))
                     .borders(Borders::LEFT | Borders::RIGHT)
+                    .double_border()
                     .render(&mut f, chunks[1]);
             }
         })?;

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -54,4 +54,5 @@ pub mod double {
     pub const VERTICAL_RIGHT: &str = "╠";
     pub const HORIZONTAL_DOWN: &str = "╦";
     pub const HORIZONTAL_UP: &str = "╩";
+    pub const CROSS: &str = "╬";
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -35,3 +35,23 @@ pub mod line {
 }
 
 pub const DOT: &str = "•";
+
+pub mod rounded {
+    pub const TOP_RIGHT: &str = "╮";
+    pub const TOP_LEFT: &str = "╭";
+    pub const BOTTOM_RIGHT: &str = "╯";
+    pub const BOTTOM_LEFT: &str = "╰";
+}
+
+pub mod double {
+    pub const VERTICAL: &str = "║";
+    pub const HORIZONTAL: &str = "═";
+    pub const TOP_RIGHT: &str = "╗";
+    pub const TOP_LEFT: &str = "╔";
+    pub const BOTTOM_RIGHT: &str = "╝";
+    pub const BOTTOM_LEFT: &str = "╚";
+    pub const VERTICAL_LEFT: &str = "╣";
+    pub const VERTICAL_RIGHT: &str = "╠";
+    pub const HORIZONTAL_DOWN: &str = "╦";
+    pub const HORIZONTAL_UP: &str = "╩";
+}

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1,7 +1,7 @@
 use crate::buffer::Buffer;
 use crate::layout::Rect;
 use crate::style::Style;
-use crate::symbols::line;
+use crate::symbols::{double, line, rounded};
 use crate::widgets::{Borders, Widget};
 
 /// Base widget to be used with all upper level ones. It may be used to display a box border around
@@ -71,6 +71,14 @@ impl<'a> Block<'a> {
     pub fn borders(mut self, flag: Borders) -> Block<'a> {
         self.borders = flag;
         self
+    }
+
+    pub fn rounded(self) -> RoundedBlock<'a> {
+        RoundedBlock::from(self)
+    }
+
+    pub fn double_border(self) -> DoubleBlock<'a> {
+        DoubleBlock::from(self)
     }
 
     /// Compute the inner area of a block based on its border visibility rules.
@@ -156,6 +164,355 @@ impl<'a> Widget for Block<'a> {
         if self.borders.contains(Borders::RIGHT | Borders::BOTTOM) {
             buf.get_mut(area.right() - 1, area.bottom() - 1)
                 .set_symbol(line::BOTTOM_RIGHT)
+                .set_style(self.border_style);
+        }
+
+        if area.width > 2 {
+            if let Some(title) = self.title {
+                let lx = if self.borders.intersects(Borders::LEFT) {
+                    1
+                } else {
+                    0
+                };
+                let rx = if self.borders.intersects(Borders::RIGHT) {
+                    1
+                } else {
+                    0
+                };
+                let width = area.width - lx - rx;
+                buf.set_stringn(
+                    area.left() + lx,
+                    area.top(),
+                    title,
+                    width as usize,
+                    self.title_style,
+                );
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct RoundedBlock<'a> {
+    /// Optional title place on the upper left of the block
+    title: Option<&'a str>,
+    /// Title style
+    title_style: Style,
+    /// Visible borders
+    borders: Borders,
+    /// Border style
+    border_style: Style,
+    /// Widget style
+    style: Style,
+}
+
+impl<'a> From<Block<'a>> for RoundedBlock<'a> {
+    fn from(block: Block<'a>) -> RoundedBlock<'a> {
+        RoundedBlock {
+            title: block.title,
+            title_style: block.title_style,
+            borders: block.borders,
+            border_style: block.border_style,
+            style: block.style,
+        }
+    }
+}
+
+impl<'a> Default for RoundedBlock<'a> {
+    fn default() -> RoundedBlock<'a> {
+        RoundedBlock {
+            title: None,
+            title_style: Default::default(),
+            borders: Borders::NONE,
+            border_style: Default::default(),
+            style: Default::default(),
+        }
+    }
+}
+
+impl<'a> RoundedBlock<'a> {
+    pub fn title(mut self, title: &'a str) -> RoundedBlock<'a> {
+        self.title = Some(title);
+        self
+    }
+
+    pub fn title_style(mut self, style: Style) -> RoundedBlock<'a> {
+        self.title_style = style;
+        self
+    }
+
+    pub fn border_style(mut self, style: Style) -> RoundedBlock<'a> {
+        self.border_style = style;
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> RoundedBlock<'a> {
+        self.style = style;
+        self
+    }
+
+    pub fn borders(mut self, flag: Borders) -> RoundedBlock<'a> {
+        self.borders = flag;
+        self
+    }
+
+    /// Compute the inner area of a block based on its border visibility rules.
+    pub fn inner(&self, area: Rect) -> Rect {
+        if area.width < 2 || area.height < 2 {
+            return Rect::default();
+        }
+        let mut inner = area;
+        if self.borders.intersects(Borders::LEFT) {
+            inner.x += 1;
+            inner.width -= 1;
+        }
+        if self.borders.intersects(Borders::TOP) || self.title.is_some() {
+            inner.y += 1;
+            inner.height -= 1;
+        }
+        if self.borders.intersects(Borders::RIGHT) {
+            inner.width -= 1;
+        }
+        if self.borders.intersects(Borders::BOTTOM) {
+            inner.height -= 1;
+        }
+        inner
+    }
+}
+
+impl<'a> Widget for RoundedBlock<'a> {
+    fn draw(&mut self, area: Rect, buf: &mut Buffer) {
+        if area.width < 2 || area.height < 2 {
+            return;
+        }
+
+        self.background(area, buf, self.style.bg);
+
+        // Sides
+        if self.borders.intersects(Borders::LEFT) {
+            for y in area.top()..area.bottom() {
+                buf.get_mut(area.left(), y)
+                    .set_symbol(line::VERTICAL)
+                    .set_style(self.border_style);
+            }
+        }
+        if self.borders.intersects(Borders::TOP) {
+            for x in area.left()..area.right() {
+                buf.get_mut(x, area.top())
+                    .set_symbol(line::HORIZONTAL)
+                    .set_style(self.border_style);
+            }
+        }
+        if self.borders.intersects(Borders::RIGHT) {
+            let x = area.right() - 1;
+            for y in area.top()..area.bottom() {
+                buf.get_mut(x, y)
+                    .set_symbol(line::VERTICAL)
+                    .set_style(self.border_style);
+            }
+        }
+        if self.borders.intersects(Borders::BOTTOM) {
+            let y = area.bottom() - 1;
+            for x in area.left()..area.right() {
+                buf.get_mut(x, y)
+                    .set_symbol(line::HORIZONTAL)
+                    .set_style(self.border_style);
+            }
+        }
+
+        // Corners
+        if self.borders.contains(Borders::LEFT | Borders::TOP) {
+            buf.get_mut(area.left(), area.top())
+                .set_symbol(rounded::TOP_LEFT)
+                .set_style(self.border_style);
+        }
+        if self.borders.contains(Borders::RIGHT | Borders::TOP) {
+            buf.get_mut(area.right() - 1, area.top())
+                .set_symbol(rounded::TOP_RIGHT)
+                .set_style(self.border_style);
+        }
+        if self.borders.contains(Borders::LEFT | Borders::BOTTOM) {
+            buf.get_mut(area.left(), area.bottom() - 1)
+                .set_symbol(rounded::BOTTOM_LEFT)
+                .set_style(self.border_style);
+        }
+        if self.borders.contains(Borders::RIGHT | Borders::BOTTOM) {
+            buf.get_mut(area.right() - 1, area.bottom() - 1)
+                .set_symbol(rounded::BOTTOM_RIGHT)
+                .set_style(self.border_style);
+        }
+
+        if area.width > 2 {
+            if let Some(title) = self.title {
+                let lx = if self.borders.intersects(Borders::LEFT) {
+                    1
+                } else {
+                    0
+                };
+                let rx = if self.borders.intersects(Borders::RIGHT) {
+                    1
+                } else {
+                    0
+                };
+                let width = area.width - lx - rx;
+                buf.set_stringn(
+                    area.left() + lx,
+                    area.top(),
+                    title,
+                    width as usize,
+                    self.title_style,
+                );
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct DoubleBlock<'a> {
+    /// Optional title place on the upper left of the block
+    title: Option<&'a str>,
+    /// Title style
+    title_style: Style,
+    /// Visible borders
+    borders: Borders,
+    /// Border style
+    border_style: Style,
+    /// Widget style
+    style: Style,
+}
+
+impl<'a> From<Block<'a>> for DoubleBlock<'a> {
+    fn from(block: Block<'a>) -> DoubleBlock<'a> {
+        DoubleBlock {
+            title: block.title,
+            title_style: block.title_style,
+            borders: block.borders,
+            border_style: block.border_style,
+            style: block.style,
+        }
+    }
+}
+impl<'a> Default for DoubleBlock<'a> {
+    fn default() -> DoubleBlock<'a> {
+        DoubleBlock {
+            title: None,
+            title_style: Default::default(),
+            borders: Borders::NONE,
+            border_style: Default::default(),
+            style: Default::default(),
+        }
+    }
+}
+
+impl<'a> DoubleBlock<'a> {
+    pub fn title(mut self, title: &'a str) -> DoubleBlock<'a> {
+        self.title = Some(title);
+        self
+    }
+
+    pub fn title_style(mut self, style: Style) -> DoubleBlock<'a> {
+        self.title_style = style;
+        self
+    }
+
+    pub fn border_style(mut self, style: Style) -> DoubleBlock<'a> {
+        self.border_style = style;
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> DoubleBlock<'a> {
+        self.style = style;
+        self
+    }
+
+    pub fn borders(mut self, flag: Borders) -> DoubleBlock<'a> {
+        self.borders = flag;
+        self
+    }
+
+    /// Compute the inner area of a block based on its border visibility rules.
+    pub fn inner(&self, area: Rect) -> Rect {
+        if area.width < 2 || area.height < 2 {
+            return Rect::default();
+        }
+        let mut inner = area;
+        if self.borders.intersects(Borders::LEFT) {
+            inner.x += 1;
+            inner.width -= 1;
+        }
+        if self.borders.intersects(Borders::TOP) || self.title.is_some() {
+            inner.y += 1;
+            inner.height -= 1;
+        }
+        if self.borders.intersects(Borders::RIGHT) {
+            inner.width -= 1;
+        }
+        if self.borders.intersects(Borders::BOTTOM) {
+            inner.height -= 1;
+        }
+        inner
+    }
+}
+
+impl<'a> Widget for DoubleBlock<'a> {
+    fn draw(&mut self, area: Rect, buf: &mut Buffer) {
+        if area.width < 2 || area.height < 2 {
+            return;
+        }
+
+        self.background(area, buf, self.style.bg);
+
+        // Sides
+        if self.borders.intersects(Borders::LEFT) {
+            for y in area.top()..area.bottom() {
+                buf.get_mut(area.left(), y)
+                    .set_symbol(double::VERTICAL)
+                    .set_style(self.border_style);
+            }
+        }
+        if self.borders.intersects(Borders::TOP) {
+            for x in area.left()..area.right() {
+                buf.get_mut(x, area.top())
+                    .set_symbol(double::HORIZONTAL)
+                    .set_style(self.border_style);
+            }
+        }
+        if self.borders.intersects(Borders::RIGHT) {
+            let x = area.right() - 1;
+            for y in area.top()..area.bottom() {
+                buf.get_mut(x, y)
+                    .set_symbol(double::VERTICAL)
+                    .set_style(self.border_style);
+            }
+        }
+        if self.borders.intersects(Borders::BOTTOM) {
+            let y = area.bottom() - 1;
+            for x in area.left()..area.right() {
+                buf.get_mut(x, y)
+                    .set_symbol(double::HORIZONTAL)
+                    .set_style(self.border_style);
+            }
+        }
+
+        // Corners
+        if self.borders.contains(Borders::LEFT | Borders::TOP) {
+            buf.get_mut(area.left(), area.top())
+                .set_symbol(double::TOP_LEFT)
+                .set_style(self.border_style);
+        }
+        if self.borders.contains(Borders::RIGHT | Borders::TOP) {
+            buf.get_mut(area.right() - 1, area.top())
+                .set_symbol(double::TOP_RIGHT)
+                .set_style(self.border_style);
+        }
+        if self.borders.contains(Borders::LEFT | Borders::BOTTOM) {
+            buf.get_mut(area.left(), area.bottom() - 1)
+                .set_symbol(double::BOTTOM_LEFT)
+                .set_style(self.border_style);
+        }
+        if self.borders.contains(Borders::RIGHT | Borders::BOTTOM) {
+            buf.get_mut(area.right() - 1, area.bottom() - 1)
+                .set_symbol(double::BOTTOM_RIGHT)
                 .set_style(self.border_style);
         }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -15,6 +15,7 @@ mod tabs;
 
 pub use self::barchart::BarChart;
 pub use self::block::Block;
+pub use self::block::BorderType;
 pub use self::chart::{Axis, Chart, Dataset, Marker};
 pub use self::gauge::Gauge;
 pub use self::list::{List, SelectableList};


### PR DESCRIPTION
This PR will implement a Blocky trait that defines the methods needed for drawing a block. There are three block types: Block, RoundedBlock, and DoubleBlock. The only differences are the unicode characters used to draw the borders. The RoundedBlock and DoubleBlock structs and methods will only be implemented when user applies the "rounded" and "double" features. This could avoid complicating things if simplicity is the goal.