### PR TITLE
Added a verticle 'cross' to the symbols as it was missing

### DIFF
--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -31,6 +31,7 @@ pub mod line {
     pub const VERTICAL_RIGHT: &str = "├";
     pub const HORIZONTAL_DOWN: &str = "┬";
     pub const HORIZONTAL_UP: &str = "┴";
+    pub const CROSS: &str = "┼";
 }
 
 pub const DOT: &str = "•";


### PR DESCRIPTION
An intersecting column and row where the row is not at the top or bottom intersect as a cross, the symbols::line module has every other intersection of the line so it makes sense that this should be added as well. 

Attached is my use case for this. Notice the cross symbol highlighted in red. 
![2019-11-30-145358_1256x680_scrot](https://user-images.githubusercontent.com/24379098/69906465-f1b2f400-1380-11ea-8a63-a0881cef18cb.png)
