### PR TITLE
Fix: title_style was not used to style the axis title

### DIFF
--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -360,12 +360,12 @@ where
 
         if let Some((x, y)) = layout.title_x {
             let title = self.x_axis.title.unwrap();
-            buf.set_string(x, y, title, self.x_axis.style);
+            buf.set_string(x, y, title, self.x_axis.title_style);
         }
 
         if let Some((x, y)) = layout.title_y {
             let title = self.y_axis.title.unwrap();
-            buf.set_string(x, y, title, self.y_axis.style);
+            buf.set_string(x, y, title, self.y_axis.title_style);
         }
 
         if let Some(y) = layout.label_x {


### PR DESCRIPTION
This actually uses the set axis title style when drawing the chart widget. Until now the axis style was used.