### PR TITLE
allow controlling sparkline direction

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -19,7 +19,7 @@ pub use self::chart::{Axis, Chart, Dataset, Marker};
 pub use self::gauge::Gauge;
 pub use self::list::{List, SelectableList};
 pub use self::paragraph::Paragraph;
-pub use self::sparkline::Sparkline;
+pub use self::sparkline::{Sparkline, RenderDirection};
 pub use self::table::{Row, Table};
 pub use self::tabs::Tabs;
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -19,7 +19,7 @@ pub use self::chart::{Axis, Chart, Dataset, Marker};
 pub use self::gauge::Gauge;
 pub use self::list::{List, SelectableList};
 pub use self::paragraph::Paragraph;
-pub use self::sparkline::{Sparkline, RenderDirection};
+pub use self::sparkline::{RenderDirection, Sparkline};
 pub use self::table::{Row, Table};
 pub use self::tabs::Tabs;
 

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -31,6 +31,13 @@ pub struct Sparkline<'a> {
     /// The maximum value to take to compute the maximum bar height (if nothing is specified, the
     /// widget uses the max of the dataset)
     max: Option<u64>,
+    // The direction to render the sparkine, either from left to right, or from right to left
+    direction: RenderDirection,
+}
+
+pub enum RenderDirection {
+    LTR,
+    RTL
 }
 
 impl<'a> Default for Sparkline<'a> {
@@ -40,6 +47,7 @@ impl<'a> Default for Sparkline<'a> {
             style: Default::default(),
             data: &[],
             max: None,
+            direction: RenderDirection::LTR,
         }
     }
 }
@@ -64,6 +72,12 @@ impl<'a> Sparkline<'a> {
         self.max = Some(max);
         self
     }
+
+    pub fn direction(mut self, direction: RenderDirection) -> Sparkline<'a> {
+        self.direction = direction;
+        self
+    }
+
 }
 
 impl<'a> Widget for Sparkline<'a> {
@@ -110,7 +124,11 @@ impl<'a> Widget for Sparkline<'a> {
                     7 => bar::SEVEN_EIGHTHS,
                     _ => bar::FULL,
                 };
-                buf.get_mut(spark_area.left() + i as u16, spark_area.top() + j)
+                let x = match self.direction {
+                    RenderDirection::LTR => spark_area.left() + i as u16,
+                    RenderDirection::RTL => spark_area.right() - i as u16 - 1
+                };
+                buf.get_mut(x, spark_area.top() + j)
                     .set_symbol(symbol)
                     .set_fg(self.style.fg)
                     .set_bg(self.style.bg);

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -37,7 +37,7 @@ pub struct Sparkline<'a> {
 
 pub enum RenderDirection {
     LTR,
-    RTL
+    RTL,
 }
 
 impl<'a> Default for Sparkline<'a> {
@@ -77,7 +77,6 @@ impl<'a> Sparkline<'a> {
         self.direction = direction;
         self
     }
-
 }
 
 impl<'a> Widget for Sparkline<'a> {
@@ -126,7 +125,7 @@ impl<'a> Widget for Sparkline<'a> {
                 };
                 let x = match self.direction {
                     RenderDirection::LTR => spark_area.left() + i as u16,
-                    RenderDirection::RTL => spark_area.right() - i as u16 - 1
+                    RenderDirection::RTL => spark_area.right() - i as u16 - 1,
                 };
                 buf.get_mut(x, spark_area.top() + j)
                     .set_symbol(symbol)


### PR DESCRIPTION
I am rendering cpu and memory events, and would like them to stream in from the right to the left. However, if I populate the dataset by appending new events to the end, the data doesn't always fill the screen, since the data size does not necessarily match the final width of the rendered box. This allows rendering the elements from starting from the right, with left to right remaining the default.