### PR TITLE
Mark Style::* functions `const`

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -114,30 +114,33 @@ pub struct Style {
 
 impl Default for Style {
     fn default() -> Style {
+        Style::new()
+    }
+}
+
+impl Style {
+    pub const fn new() -> Self {
         Style {
             fg: Color::Reset,
             bg: Color::Reset,
             modifier: Modifier::empty(),
         }
     }
-}
-
-impl Style {
     pub fn reset(&mut self) {
         self.fg = Color::Reset;
         self.bg = Color::Reset;
         self.modifier = Modifier::empty();
     }
 
-    pub fn fg(mut self, color: Color) -> Style {
+    pub const fn fg(mut self, color: Color) -> Style {
         self.fg = color;
         self
     }
-    pub fn bg(mut self, color: Color) -> Style {
+    pub const fn bg(mut self, color: Color) -> Style {
         self.bg = color;
         self
     }
-    pub fn modifier(mut self, modifier: Modifier) -> Style {
+    pub const fn modifier(mut self, modifier: Modifier) -> Style {
         self.modifier = modifier;
         self
     }

--- a/tests/paragraph.rs
+++ b/tests/paragraph.rs
@@ -4,8 +4,7 @@ use tui::layout::Alignment;
 use tui::widgets::{Block, Borders, Paragraph, Text, Widget};
 use tui::Terminal;
 
-const SAMPLE_STRING: &str =
-    "The library is based on the principle of immediate rendering with \
+const SAMPLE_STRING: &str = "The library is based on the principle of immediate rendering with \
      intermediate buffers. This means that at each new frame you should build all widgets that are \
      supposed to be part of the UI. While providing a great flexibility for rich and \
      interactive UI, this may introduce overhead for highly dynamic content.";


### PR DESCRIPTION
Fix #223.

I tested the changes with the following snippet, just to verify that the changes actually enabled the use
of `const FOO: Style...`. Since the test is quite useless I removed them from the PR.

```rust
#[cfg(test)]
mod tests {
    use super::*;

    const RED: Color = Color::Red;
    const RED_STYLE: Style = Style::new().fg(RED);
    const RED_DIMMED: Style = Style::new()
        .fg(Color::Red)
        .bg(Color::Blue)
        .modifier(Modifier::DIM);

    #[test]
    fn test_const() {
        assert_eq!(RED, Color::Red);
        assert_eq!(
            RED_STYLE,
            Style {
                fg: Color::Red,
                ..Style::default()
            }
        );
        assert_eq!(
            RED_DIMMED,
            Style {
                fg: Color::Red,
                bg: Color::Blue,
                modifier: Modifier::DIM,
            }
        );
    }
}
```