### PR TITLE
docs: update to build more backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ rand = "0.7"
 failure = "0.1"
 structopt = "0.3"
 
+[package.metadata.docs.rs]
+# Have docs.rs build with more backends then just the default
+features = ["termion", "crossterm", "curses"]
+
 [[example]]
 name = "canvas"
 path = "examples/canvas.rs"


### PR DESCRIPTION
Enable more backends to be built into the default docs than just
termion. These were the only backends that built in a representative
environment of docs.rs. Options come from https://docs.rs/about#metadata