### PR TITLE
Add zenith to apps using tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can run all examples by running `make run-examples`.
 * [spotify-tui](https://github.com/Rigellute/spotify-tui)
 * [bandwhich](https://github.com/imsnif/bandwhich)
 * [ytop](https://github.com/cjbassi/ytop)
+* [zenith](https://github.com/bvaisvil/zenith)
 
 ### Alternatives
 


### PR DESCRIPTION

Using `tui-rs` as been great and I'd like to add my app zenith to the `Apps using Tui` section.

