### PR TITLE
refactor(canvas): update shape drawing strategy

### DIFF
--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -20,10 +20,10 @@ use crate::util::event::{Config, Event, Events};
 struct App {
     x: f64,
     y: f64,
-    ball: Rect,
+    ball: Rectangle,
     playground: Rect,
-    vx: u16,
-    vy: u16,
+    vx: f64,
+    vy: f64,
     dir_x: bool,
     dir_y: bool,
 }
@@ -33,21 +33,29 @@ impl App {
         App {
             x: 0.0,
             y: 0.0,
-            ball: Rect::new(10, 30, 10, 10),
+            ball: Rectangle {
+                x: 10.0,
+                y: 30.0,
+                width: 10.0,
+                height: 10.0,
+                color: Color::Yellow,
+            },
             playground: Rect::new(10, 10, 100, 100),
-            vx: 1,
-            vy: 1,
+            vx: 1.0,
+            vy: 1.0,
             dir_x: true,
             dir_y: true,
         }
     }
 
     fn update(&mut self) {
-        if self.ball.left() < self.playground.left() || self.ball.right() > self.playground.right()
+        if self.ball.x < self.playground.left() as f64
+            || self.ball.x + self.ball.width > self.playground.right() as f64
         {
             self.dir_x = !self.dir_x;
         }
-        if self.ball.top() < self.playground.top() || self.ball.bottom() > self.playground.bottom()
+        if self.ball.y < self.playground.top() as f64
+            || self.ball.y + self.ball.height > self.playground.bottom() as f64
         {
             self.dir_y = !self.dir_y;
         }
@@ -77,7 +85,7 @@ fn main() -> Result<(), failure::Error> {
 
     // Setup event handlers
     let config = Config {
-        tick_rate: Duration::from_millis(100),
+        tick_rate: Duration::from_millis(250),
         ..Default::default()
     };
     let events = Events::with_config(config);
@@ -106,10 +114,7 @@ fn main() -> Result<(), failure::Error> {
             let canvas = Canvas::default()
                 .block(Block::default().borders(Borders::ALL).title("Pong"))
                 .paint(|ctx| {
-                    ctx.draw(&Rectangle {
-                        rect: app.ball,
-                        color: Color::Yellow,
-                    });
+                    ctx.draw(&app.ball);
                 })
                 .x_bounds([10.0, 110.0])
                 .y_bounds([10.0, 110.0]);

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -259,12 +259,10 @@ where
             });
             ctx.layer();
             ctx.draw(&Rectangle {
-                rect: Rect {
-                    x: 0,
-                    y: 30,
-                    width: 10,
-                    height: 10,
-                },
+                x: 0.0,
+                y: 30.0,
+                width: 10.0,
+                height: 10.0,
                 color: Color::Yellow,
             });
             for (i, s1) in app.servers.iter().enumerate() {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -47,8 +47,8 @@ impl Constraint {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Margin {
-    vertical: u16,
-    horizontal: u16,
+    pub vertical: u16,
+    pub horizontal: u16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -58,7 +58,6 @@ pub enum Alignment {
     Right,
 }
 
-// TODO: enforce constraints size once const generics has landed
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Layout {
     direction: Direction,

--- a/src/widgets/canvas/line.rs
+++ b/src/widgets/canvas/line.rs
@@ -1,7 +1,10 @@
-use super::Shape;
-use crate::style::Color;
+use crate::{
+    style::Color,
+    widgets::canvas::{Painter, Shape},
+};
 
 /// Shape to draw a line from (x1, y1) to (x2, y2) with the given color
+#[derive(Debug, Clone)]
 pub struct Line {
     pub x1: f64,
     pub y1: f64,
@@ -10,63 +13,77 @@ pub struct Line {
     pub color: Color,
 }
 
-pub struct LineIterator {
-    x: f64,
-    y: f64,
-    dx: f64,
-    dy: f64,
-    dir_x: f64,
-    dir_y: f64,
-    current: f64,
-    end: f64,
-}
-
-impl Iterator for LineIterator {
-    type Item = (f64, f64);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current < self.end {
-            let pos = (
-                self.x + (self.current * self.dx) / self.end * self.dir_x,
-                self.y + (self.current * self.dy) / self.end * self.dir_y,
-            );
-            self.current += 1.0;
-            Some(pos)
+impl Shape for Line {
+    fn draw(&self, painter: &mut Painter) {
+        let (x1, y1) = match painter.get_point(self.x1, self.y1) {
+            Some(c) => c,
+            None => return,
+        };
+        let (x2, y2) = match painter.get_point(self.x2, self.y2) {
+            Some(c) => c,
+            None => return,
+        };
+        let (dx, x_range) = if x2 >= x1 {
+            (x2 - x1, x1..=x2)
         } else {
-            None
+            (x1 - x2, x2..=x1)
+        };
+        let (dy, y_range) = if y2 >= y1 {
+            (y2 - y1, y1..=y2)
+        } else {
+            (y1 - y2, y2..=y1)
+        };
+
+        if dx == 0 {
+            for y in y_range {
+                painter.paint(x1, y, self.color);
+            }
+        } else if dy == 0 {
+            for x in x_range {
+                painter.paint(x, y1, self.color);
+            }
+        } else if dy < dx {
+            if x1 > x2 {
+                draw_line_low(painter, x2, y2, x1, y1, self.color);
+            } else {
+                draw_line_low(painter, x1, y1, x2, y2, self.color);
+            }
+        } else {
+            if y1 > y2 {
+                draw_line_high(painter, x2, y2, x1, y1, self.color);
+            } else {
+                draw_line_high(painter, x1, y1, x2, y2, self.color);
+            }
         }
     }
 }
 
-impl<'a> IntoIterator for &'a Line {
-    type Item = (f64, f64);
-    type IntoIter = LineIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let dx = self.x1.max(self.x2) - self.x1.min(self.x2);
-        let dy = self.y1.max(self.y2) - self.y1.min(self.y2);
-        let dir_x = if self.x1 <= self.x2 { 1.0 } else { -1.0 };
-        let dir_y = if self.y1 <= self.y2 { 1.0 } else { -1.0 };
-        let end = dx.max(dy);
-        LineIterator {
-            x: self.x1,
-            y: self.y1,
-            dx,
-            dy,
-            dir_x,
-            dir_y,
-            current: 0.0,
-            end,
+fn draw_line_low(painter: &mut Painter, x1: usize, y1: usize, x2: usize, y2: usize, color: Color) {
+    let dx = (x2 - x1) as isize;
+    let dy = (y2 as isize - y1 as isize).abs();
+    let mut d = 2 * dy - dx;
+    let mut y = y1;
+    for x in x1..=x2 {
+        painter.paint(x, y, color);
+        if d > 0 {
+            y = if y1 > y2 { y - 1 } else { y + 1 };
+            d -= 2 * dx;
         }
+        d += 2 * dy;
     }
 }
 
-impl<'a> Shape<'a> for Line {
-    fn color(&self) -> Color {
-        self.color
-    }
-
-    fn points(&'a self) -> Box<dyn Iterator<Item = (f64, f64)> + 'a> {
-        Box::new(self.into_iter())
+fn draw_line_high(painter: &mut Painter, x1: usize, y1: usize, x2: usize, y2: usize, color: Color) {
+    let dx = (x2 as isize - x1 as isize).abs();
+    let dy = (y2 - y1) as isize;
+    let mut d = 2 * dx - dy;
+    let mut x = x1;
+    for y in y1..=y2 {
+        painter.paint(x, y, color);
+        if d > 0 {
+            x = if x1 > x2 { x - 1 } else { x + 1 };
+            d -= 2 * dy;
+        }
+        d += 2 * dx;
     }
 }

--- a/src/widgets/canvas/map.rs
+++ b/src/widgets/canvas/map.rs
@@ -1,9 +1,12 @@
-use crate::style::Color;
-use crate::widgets::canvas::points::PointsIterator;
-use crate::widgets::canvas::world::{WORLD_HIGH_RESOLUTION, WORLD_LOW_RESOLUTION};
-use crate::widgets::canvas::Shape;
+use crate::{
+    style::Color,
+    widgets::canvas::{
+        world::{WORLD_HIGH_RESOLUTION, WORLD_LOW_RESOLUTION},
+        Painter, Shape,
+    },
+};
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum MapResolution {
     Low,
     High,
@@ -19,6 +22,7 @@ impl MapResolution {
 }
 
 /// Shape to draw a world map with the given resolution and color
+#[derive(Debug, Clone)]
 pub struct Map {
     pub resolution: MapResolution,
     pub color: Color,
@@ -33,19 +37,12 @@ impl Default for Map {
     }
 }
 
-impl<'a> Shape<'a> for Map {
-    fn color(&self) -> Color {
-        self.color
-    }
-    fn points(&'a self) -> Box<dyn Iterator<Item = (f64, f64)> + 'a> {
-        Box::new(self.into_iter())
-    }
-}
-
-impl<'a> IntoIterator for &'a Map {
-    type Item = (f64, f64);
-    type IntoIter = PointsIterator<'a>;
-    fn into_iter(self) -> Self::IntoIter {
-        PointsIterator::from(self.resolution.data())
+impl Shape for Map {
+    fn draw(&self, painter: &mut Painter) {
+        for (x, y) in self.resolution.data() {
+            if let Some((x, y)) = painter.get_point(*x, *y) {
+                painter.paint(x, y, self.color);
+            }
+        }
     }
 }

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -1,20 +1,22 @@
-use std::slice;
-
-use super::Shape;
-use crate::style::Color;
+use crate::{
+    style::Color,
+    widgets::canvas::{Painter, Shape},
+};
 
 /// A shape to draw a group of points with the given color
+#[derive(Debug, Clone)]
 pub struct Points<'a> {
     pub coords: &'a [(f64, f64)],
     pub color: Color,
 }
 
-impl<'a> Shape<'a> for Points<'a> {
-    fn color(&self) -> Color {
-        self.color
-    }
-    fn points(&'a self) -> Box<dyn Iterator<Item = (f64, f64)> + 'a> {
-        Box::new(self.into_iter())
+impl<'a> Shape for Points<'a> {
+    fn draw(&self, painter: &mut Painter) {
+        for (x, y) in self.coords {
+            if let Some((x, y)) = painter.get_point(*x, *y) {
+                painter.paint(x, y, self.color);
+            }
+        }
     }
 }
 
@@ -23,36 +25,6 @@ impl<'a> Default for Points<'a> {
         Points {
             coords: &[],
             color: Color::Reset,
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a Points<'a> {
-    type Item = (f64, f64);
-    type IntoIter = PointsIterator<'a>;
-    fn into_iter(self) -> Self::IntoIter {
-        PointsIterator {
-            iter: self.coords.iter(),
-        }
-    }
-}
-
-pub struct PointsIterator<'a> {
-    iter: slice::Iter<'a, (f64, f64)>,
-}
-
-impl<'a> From<&'a [(f64, f64)]> for PointsIterator<'a> {
-    fn from(data: &'a [(f64, f64)]) -> PointsIterator<'a> {
-        PointsIterator { iter: data.iter() }
-    }
-}
-
-impl<'a> Iterator for PointsIterator<'a> {
-    type Item = (f64, f64);
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.iter.next() {
-            Some(p) => Some(*p),
-            None => None,
         }
     }
 }

--- a/src/widgets/canvas/rectangle.rs
+++ b/src/widgets/canvas/rectangle.rs
@@ -1,54 +1,52 @@
-use crate::layout::Rect;
-use crate::style::Color;
-use crate::widgets::canvas::{Line, Shape};
-use itertools::Itertools;
+use crate::{
+    style::Color,
+    widgets::canvas::{Line, Painter, Shape},
+};
 
 /// Shape to draw a rectangle from a `Rect` with the given color
+#[derive(Debug, Clone)]
 pub struct Rectangle {
-    pub rect: Rect,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
     pub color: Color,
 }
 
-impl<'a> Shape<'a> for Rectangle {
-    fn color(&self) -> Color {
-        self.color
-    }
-
-    fn points(&'a self) -> Box<dyn Iterator<Item = (f64, f64)> + 'a> {
-        let left_line = Line {
-            x1: f64::from(self.rect.x),
-            y1: f64::from(self.rect.y),
-            x2: f64::from(self.rect.x),
-            y2: f64::from(self.rect.y + self.rect.height),
-            color: self.color,
-        };
-        let top_line = Line {
-            x1: f64::from(self.rect.x),
-            y1: f64::from(self.rect.y + self.rect.height),
-            x2: f64::from(self.rect.x + self.rect.width),
-            y2: f64::from(self.rect.y + self.rect.height),
-            color: self.color,
-        };
-        let right_line = Line {
-            x1: f64::from(self.rect.x + self.rect.width),
-            y1: f64::from(self.rect.y),
-            x2: f64::from(self.rect.x + self.rect.width),
-            y2: f64::from(self.rect.y + self.rect.height),
-            color: self.color,
-        };
-        let bottom_line = Line {
-            x1: f64::from(self.rect.x),
-            y1: f64::from(self.rect.y),
-            x2: f64::from(self.rect.x + self.rect.width),
-            y2: f64::from(self.rect.y),
-            color: self.color,
-        };
-        Box::new(
-            left_line.into_iter().merge(
-                top_line
-                    .into_iter()
-                    .merge(right_line.into_iter().merge(bottom_line.into_iter())),
-            ),
-        )
+impl Shape for Rectangle {
+    fn draw(&self, painter: &mut Painter) {
+        let lines: [Line; 4] = [
+            Line {
+                x1: self.x,
+                y1: self.y,
+                x2: self.x,
+                y2: self.y + self.height,
+                color: self.color,
+            },
+            Line {
+                x1: self.x,
+                y1: self.y + self.height,
+                x2: self.x + self.width,
+                y2: self.y + self.height,
+                color: self.color,
+            },
+            Line {
+                x1: self.x + self.width,
+                y1: self.y,
+                x2: self.x + self.width,
+                y2: self.y + self.height,
+                color: self.color,
+            },
+            Line {
+                x1: self.x,
+                y1: self.y,
+                x2: self.x + self.width,
+                y2: self.y,
+                color: self.color,
+            },
+        ];
+        for line in &lines {
+            line.draw(painter);
+        }
     }
 }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -1,13 +1,15 @@
+use crate::{
+    buffer::Buffer,
+    layout::{Constraint, Rect},
+    style::Style,
+    symbols,
+    widgets::{
+        canvas::{Canvas, Line, Points},
+        Block, Borders, Widget,
+    },
+};
 use std::{borrow::Cow, cmp::max};
-
 use unicode_width::UnicodeWidthStr;
-
-use crate::buffer::Buffer;
-use crate::layout::{Constraint, Rect};
-use crate::style::Style;
-use crate::symbols;
-use crate::widgets::canvas::{Canvas, Line, Points};
-use crate::widgets::{Block, Borders, Widget};
 
 /// An X or Y axis for the chart widget
 pub struct Axis<'a, L>


### PR DESCRIPTION
* Update the `Shape` trait. Instead of returning an iterator of point, all
shapes are now aware of the surface they will be drawn to through a `Painter`.
In order to draw themselves, they paint points of the "braille grid".
* Rewrite how lines are drawn using a common line drawing algorithm (Bresenham).

fix #232 