### PR TITLE
Add `oha` to the "apps using tui" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You can run all examples by running `make run-examples`.
 * [ytop](https://github.com/cjbassi/ytop)
 * [zenith](https://github.com/bvaisvil/zenith)
 * [bottom](https://github.com/ClementTsang/bottom)
+* [oha](https://github.com/hatoo/oha)
 
 ### Alternatives
 


### PR DESCRIPTION
Thank you for developing this project!
I've created [`oha`](https://github.com/hatoo/oha) which is using `tui-rs`.
I'd like to add `oha` to the `Apps using tui` section.