### PR TITLE
feat: Add clean option to block

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -367,6 +367,15 @@ impl Buffer {
         }
     }
 
+    /// Reset cells in given area in the buffer
+    pub fn reset_area(&mut self, area: Rect) {
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                self.get_mut(x, y).reset();
+            }
+        }
+    }
+
     /// Merge an other buffer into this one
     pub fn merge(&mut self, other: &Buffer) {
         let area = self.area.union(other.area);

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -42,6 +42,8 @@ pub struct Block<'a> {
     border_type: BorderType,
     /// Widget style
     style: Style,
+    /// Whether to reset the background
+    clean: bool,
 }
 
 impl<'a> Default for Block<'a> {
@@ -53,6 +55,7 @@ impl<'a> Default for Block<'a> {
             border_style: Default::default(),
             border_type: BorderType::Plain,
             style: Default::default(),
+            clean: false,
         }
     }
 }
@@ -88,6 +91,11 @@ impl<'a> Block<'a> {
         self
     }
 
+    pub fn clean(mut self, clean: bool) -> Block<'a> {
+        self.clean = clean;
+        self
+    }
+
     /// Compute the inner area of a block based on its border visibility rules.
     pub fn inner(&self, area: Rect) -> Rect {
         if area.width < 2 || area.height < 2 {
@@ -119,6 +127,10 @@ impl<'a> Widget for Block<'a> {
         }
 
         buf.set_background(area, self.style.bg);
+
+        if self.clean {
+            buf.reset_area(area);
+        }
 
         // Sides
         if self.borders.intersects(Borders::LEFT) {


### PR DESCRIPTION
Related to: #211 

I find the need to make a pop-up dialog in my program, but drawing widgets over drawn buffer will not clean all the underlying cells. Thus I add a `reset_area` function to `buffer.rs` to reset cells in a certain `Rect`. This will make it possible to implement a dialog. 

I also adds a `clean` option to `Block` to clean the cells first before rendering. Other widgets are untouched.

![Screenshot from 2020-03-14 13-39-03](https://user-images.githubusercontent.com/25698503/76676329-4c552080-65fd-11ea-90bc-88c53e6934fd.png)

Here is a minimal-example to create a dialog:
```rust
content = frame.size();

// The main view
frame.render_widget(
    MainViewWidget::new(self.app),
    content,
);

// The dialogue
if self.app.show_save_model {
    let modal_messages: [Text, _] = ...;
    let modal_buttons: [Text, _] = ...;
    let messages_blk: Block = ...;
    let buttons_blk: Block = ...;
    let (margin_x, margin_y) = calculate_margins(...);

    let layout = Layout::default()
        .direction(Direction::Vertical)
        .constraints([Constraint::Length(6), Constraint::Length(2)].as_ref())
        .vertical_margin(margin_y)
        .horizontal_margin(margin_x)
        .split(content);

    frame.render_widget(
        Paragraph::new(modal_messages.iter()).block(messages_blk.clean(true)),
        layout[0],
    )
    frame.render_widget(
        Buttons::new(buttons_group.iter()).block(buttons_blk.clean(true)),
        layout[1],
    )
}
```
