### PR TITLE
docs: Fix missing code block fence for hidden_legend_constraints

### DIFF
--- a/src/widgets/canvas/line.rs
+++ b/src/widgets/canvas/line.rs
@@ -64,13 +64,7 @@ fn draw_line_low(painter: &mut Painter, x1: usize, y1: usize, x2: usize, y2: usi
     for x in x1..=x2 {
         painter.paint(x, y, color);
         if d > 0 {
-            y = if y1 > y2 {
-                y.saturating_sub(1)
-            } else if y1 == y2 {
-                y
-            } else {
-                y + 1
-            };
+            y = if y1 > y2 { y - 1 } else { y + 1 };
             d -= 2 * dx;
         }
         d += 2 * dy;
@@ -85,13 +79,7 @@ fn draw_line_high(painter: &mut Painter, x1: usize, y1: usize, x2: usize, y2: us
     for y in y1..=y2 {
         painter.paint(x, y, color);
         if d > 0 {
-            x = if x1 > x2 {
-                x.saturating_sub(1)
-            } else if x1 == x2 {
-                x
-            } else {
-                x + 1
-            };
+            x = if x1 > x2 { x - 1 } else { x + 1 };
             d -= 2 * dy;
         }
         d += 2 * dx;

--- a/src/widgets/canvas/line.rs
+++ b/src/widgets/canvas/line.rs
@@ -64,7 +64,13 @@ fn draw_line_low(painter: &mut Painter, x1: usize, y1: usize, x2: usize, y2: usi
     for x in x1..=x2 {
         painter.paint(x, y, color);
         if d > 0 {
-            y = if y1 > y2 { y - 1 } else { y + 1 };
+            y = if y1 > y2 {
+                y.saturating_sub(1)
+            } else if y1 == y2 {
+                y
+            } else {
+                y + 1
+            };
             d -= 2 * dx;
         }
         d += 2 * dy;
@@ -79,7 +85,13 @@ fn draw_line_high(painter: &mut Painter, x1: usize, y1: usize, x2: usize, y2: us
     for y in y1..=y2 {
         painter.paint(x, y, color);
         if d > 0 {
-            x = if x1 > x2 { x - 1 } else { x + 1 };
+            x = if x1 > x2 {
+                x.saturating_sub(1)
+            } else if x1 == x2 {
+                x
+            } else {
+                x + 1
+            };
             d -= 2 * dy;
         }
         d += 2 * dx;

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -304,6 +304,7 @@ where
     /// // or if its height is greater than 25% of the total widget height.
     /// let _chart: Chart<String, String> = Chart::default()
     ///     .hidden_legend_constraints(constraints);
+    /// ```
     pub fn hidden_legend_constraints(
         mut self,
         constraints: (Constraint, Constraint),

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -500,14 +500,16 @@ where
                         color: dataset.style.fg,
                     });
                     if let GraphType::Line = dataset.graph_type {
-                        for i in 0..dataset.data.len() - 1 {
-                            ctx.draw(&Line {
-                                x1: dataset.data[i].0,
-                                y1: dataset.data[i].1,
-                                x2: dataset.data[i + 1].0,
-                                y2: dataset.data[i + 1].1,
-                                color: dataset.style.fg,
-                            })
+                        if !dataset.data.is_empty() {
+                            for i in 0..dataset.data.len() - 1 {
+                                ctx.draw(&Line {
+                                    x1: dataset.data[i].0,
+                                    y1: dataset.data[i].1,
+                                    x2: dataset.data[i + 1].0,
+                                    y2: dataset.data[i + 1].1,
+                                    color: dataset.style.fg,
+                                })
+                            }
                         }
                     }
                 })

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -500,16 +500,14 @@ where
                         color: dataset.style.fg,
                     });
                     if let GraphType::Line = dataset.graph_type {
-                        if !dataset.data.is_empty() {
-                            for i in 0..dataset.data.len() - 1 {
-                                ctx.draw(&Line {
-                                    x1: dataset.data[i].0,
-                                    y1: dataset.data[i].1,
-                                    x2: dataset.data[i + 1].0,
-                                    y2: dataset.data[i + 1].1,
-                                    color: dataset.style.fg,
-                                })
-                            }
+                        for data in dataset.data.windows(2) {
+                            ctx.draw(&Line {
+                                x1: data[0].0,
+                                y1: data[0].1,
+                                x2: data[1].0,
+                                y2: data[1].1,
+                                color: dataset.style.fg,
+                            })
                         }
                     }
                 })

--- a/tests/chart.rs
+++ b/tests/chart.rs
@@ -3,7 +3,7 @@ use tui::{
     layout::Rect,
     style::{Color, Style},
     symbols,
-    widgets::{Axis, Block, Borders, Chart, Dataset},
+    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType::Line},
     Terminal,
 };
 
@@ -20,6 +20,36 @@ fn zero_axes_ok() {
                 .data(&[(0.0, 0.0)])];
             let chart = Chart::default()
                 .block(Block::default().title("Plot").borders(Borders::ALL))
+                .x_axis(Axis::default().bounds([0.0, 0.0]).labels(&["0.0", "1.0"]))
+                .y_axis(Axis::default().bounds([0.0, 1.0]).labels(&["0.0", "1.0"]))
+                .datasets(&datasets);
+            f.render_widget(
+                chart,
+                Rect {
+                    x: 0,
+                    y: 0,
+                    width: 100,
+                    height: 100,
+                },
+            );
+        })
+        .unwrap();
+}
+
+#[test]
+fn empty_dataset_line_test() {
+    let backend = TestBackend::new(100, 100);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|mut f| {
+            let datasets = [Dataset::default().data(&[]).graph_type(Line)];
+            let chart = Chart::default()
+                .block(
+                    Block::default()
+                        .title("Empty Dataset With Line")
+                        .borders(Borders::ALL),
+                )
                 .x_axis(Axis::default().bounds([0.0, 0.0]).labels(&["0.0", "1.0"]))
                 .y_axis(Axis::default().bounds([0.0, 1.0]).labels(&["0.0", "1.0"]))
                 .datasets(&datasets);


### PR DESCRIPTION
Two things:

1.  Minor thing that I noticed when using this function.  Seems to look fine in documentation, but looked weird on stuff like VS Code.

![image](https://user-images.githubusercontent.com/34804052/79673703-15e56500-81aa-11ea-956b-03af497ce6b6.png)

2.  When using `GraphType::Line`, if the dataset is empty, you can end up with a subtraction underflow when you do the length - 1.
