### PR TITLE
chore: enable clippy on all targets and all features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --all-targets --all-features -- -D warnings
   windows:
     name: Windows
     runs-on: windows-latest

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ fmt: ## Check the format of the source code
 
 .PHONY: clippy
 clippy: ## Check the style of the source code and catch common errors
-	$(CARGO) clippy --all-features
+	$(CARGO) clippy --all-targets --all-features -- -D warnings
 
 
 # ================================ Test =======================================

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -75,13 +75,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         })?;
 
-        match events.next()? {
-            Event::Input(key) => {
-                if key == Key::Char('q') {
-                    break;
-                }
+        if let Event::Input(key) = events.next()? {
+            if key == Key::Char('q') {
+                break;
             }
-            _ => {}
         }
     }
     Ok(())

--- a/examples/curses_demo.rs
+++ b/examples/curses_demo.rs
@@ -4,7 +4,6 @@ mod util;
 
 use crate::demo::{ui, App};
 use argh::FromArgs;
-use easycurses;
 use std::{
     error::Error,
     io,
@@ -26,7 +25,8 @@ struct Cli {
 fn main() -> Result<(), Box<dyn Error>> {
     let cli: Cli = argh::from_env();
 
-    let mut backend = CursesBackend::new().ok_or(io::Error::new(io::ErrorKind::Other, ""))?;
+    let mut backend =
+        CursesBackend::new().ok_or_else(|| io::Error::new(io::ErrorKind::Other, ""))?;
     let curses = backend.get_curses_mut();
     curses.set_echo(false);
     curses.set_input_timeout(easycurses::TimeoutMode::WaitUpTo(50));
@@ -41,28 +41,25 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tick_rate = Duration::from_millis(cli.tick_rate);
     loop {
         terminal.draw(|mut f| ui::draw(&mut f, &mut app))?;
-        match terminal.backend_mut().get_curses_mut().get_input() {
-            Some(input) => {
-                match input {
-                    easycurses::Input::Character(c) => {
-                        app.on_key(c);
-                    }
-                    easycurses::Input::KeyUp => {
-                        app.on_up();
-                    }
-                    easycurses::Input::KeyDown => {
-                        app.on_down();
-                    }
-                    easycurses::Input::KeyLeft => {
-                        app.on_left();
-                    }
-                    easycurses::Input::KeyRight => {
-                        app.on_right();
-                    }
-                    _ => {}
-                };
-            }
-            _ => {}
+        if let Some(input) = terminal.backend_mut().get_curses_mut().get_input() {
+            match input {
+                easycurses::Input::Character(c) => {
+                    app.on_key(c);
+                }
+                easycurses::Input::KeyUp => {
+                    app.on_up();
+                }
+                easycurses::Input::KeyDown => {
+                    app.on_down();
+                }
+                easycurses::Input::KeyLeft => {
+                    app.on_left();
+                }
+                easycurses::Input::KeyRight => {
+                    app.on_right();
+                }
+                _ => {}
+            };
         };
         terminal.backend_mut().get_curses_mut().flush_input();
         if last_tick.elapsed() > tick_rate {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -48,13 +48,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             f.render_widget(label, size);
         })?;
 
-        match events.next()? {
-            Event::Input(key) => {
-                if key == Key::Char('q') {
-                    break;
-                }
+        if let Event::Input(key) = events.next()? {
+            if key == Key::Char('q') {
+                break;
             }
-            _ => {}
         }
     }
 

--- a/examples/demo/app.rs
+++ b/examples/demo/app.rs
@@ -1,12 +1,12 @@
 use crate::util::{RandomSignal, SinSignal, StatefulList, TabsState};
 
-const TASKS: [&'static str; 24] = [
+const TASKS: [&str; 24] = [
     "Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9", "Item10",
     "Item11", "Item12", "Item13", "Item14", "Item15", "Item16", "Item17", "Item18", "Item19",
     "Item20", "Item21", "Item22", "Item23", "Item24",
 ];
 
-const LOGS: [(&'static str, &'static str); 26] = [
+const LOGS: [(&str, &str); 26] = [
     ("Event1", "INFO"),
     ("Event2", "INFO"),
     ("Event3", "CRITICAL"),
@@ -35,7 +35,7 @@ const LOGS: [(&'static str, &'static str); 26] = [
     ("Event26", "INFO"),
 ];
 
-const EVENTS: [(&'static str, u64); 24] = [
+const EVENTS: [(&str, u64); 24] = [
     ("B1", 9),
     ("B2", 12),
     ("B3", 5),

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -42,13 +42,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             f.render_widget(block, chunks[2]);
         })?;
 
-        match events.next()? {
-            Event::Input(input) => {
-                if let Key::Char('q') = input {
-                    break;
-                }
+        if let Event::Input(input) = events.next()? {
+            if let Key::Char('q') = input {
+                break;
             }
-            _ => {}
         }
     }
 

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -94,13 +94,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         scroll += 1;
         scroll %= 10;
 
-        match events.next()? {
-            Event::Input(key) => {
-                if key == Key::Char('q') {
-                    break;
-                }
+        if let Event::Input(key) = events.next()? {
+            if key == Key::Char('q') {
+                break;
             }
-            _ => {}
         }
     }
     Ok(())

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -97,13 +97,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             f.render_widget(block, area);
         })?;
 
-        match events.next()? {
-            Event::Input(input) => {
-                if let Key::Char('q') = input {
-                    break;
-                }
+        if let Event::Input(input) = events.next()? {
+            if let Key::Char('q') = input {
+                break;
             }
-            _ => {}
         }
     }
 

--- a/examples/rustbox_demo.rs
+++ b/examples/rustbox_demo.rs
@@ -35,8 +35,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tick_rate = Duration::from_millis(cli.tick_rate);
     loop {
         terminal.draw(|mut f| ui::draw(&mut f, &mut app))?;
-        match terminal.backend().rustbox().peek_event(tick_rate, false) {
-            Ok(rustbox::Event::KeyEvent(key)) => match key {
+        if let Ok(rustbox::Event::KeyEvent(key)) =
+            terminal.backend().rustbox().peek_event(tick_rate, false)
+        {
+            match key {
                 Key::Char(c) => {
                     app.on_key(c);
                 }
@@ -53,8 +55,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     app.on_right();
                 }
                 _ => {}
-            },
-            _ => {}
+            }
         }
         if last_tick.elapsed() > tick_rate {
             app.on_tick();

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -100,7 +100,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let rows = table
                 .items
                 .iter()
-                .map(|i| Row::StyledData(i.into_iter(), normal_style));
+                .map(|i| Row::StyledData(i.iter(), normal_style));
             let t = Table::new(header.iter(), rows)
                 .block(Block::default().borders(Borders::ALL).title("Table"))
                 .highlight_style(selected_style)
@@ -113,8 +113,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             f.render_stateful_widget(t, rects[0], &mut table.state);
         })?;
 
-        match events.next()? {
-            Event::Input(key) => match key {
+        if let Event::Input(key) = events.next()? {
+            match key {
                 Key::Char('q') => {
                     break;
                 }
@@ -125,8 +125,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     table.previous();
                 }
                 _ => {}
-            },
-            _ => {}
+            }
         };
     }
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -64,16 +64,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             f.render_widget(inner, chunks[1]);
         })?;
 
-        match events.next()? {
-            Event::Input(input) => match input {
+        if let Event::Input(input) = events.next()? {
+            match input {
                 Key::Char('q') => {
                     break;
                 }
                 Key::Right => app.tabs.next(),
                 Key::Left => app.tabs.previous(),
                 _ => {}
-            },
-            _ => {}
+            }
         }
     }
     Ok(())

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -118,8 +118,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         io::stdout().flush().ok();
 
         // Handle input
-        match events.next()? {
-            Event::Input(input) => match app.input_mode {
+        if let Event::Input(input) = events.next()? {
+            match app.input_mode {
                 InputMode::Normal => match input {
                     Key::Char('e') => {
                         app.input_mode = InputMode::Editing;
@@ -146,8 +146,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     }
                     _ => {}
                 },
-            },
-            _ => {}
+            }
         }
     }
     Ok(())

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -93,7 +93,7 @@ impl<T> StatefulList<T> {
     pub fn with_items(items: Vec<T>) -> StatefulList<T> {
         StatefulList {
             state: ListState::default(),
-            items: items,
+            items,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,6 @@
 //! you might need a blank space somewhere, try to pass an additional constraint and don't use the
 //! corresponding area.
 
-#![deny(warnings)]
-
 pub mod backend;
 pub mod buffer;
 pub mod layout;

--- a/tests/chart.rs
+++ b/tests/chart.rs
@@ -47,15 +47,15 @@ fn handles_overflow() {
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(Color::Magenta))
                 .data(&[
-                    (1588298471.0, 1.0),
-                    (1588298473.0, 0.0),
-                    (1588298496.0, 1.0),
+                    (1_588_298_471.0, 1.0),
+                    (1_588_298_473.0, 0.0),
+                    (1_588_298_496.0, 1.0),
                 ])];
             let chart = Chart::default()
                 .block(Block::default().title("Plot").borders(Borders::ALL))
                 .x_axis(
                     Axis::default()
-                        .bounds([1588298471.0, 1588992600.0])
+                        .bounds([1_588_298_471.0, 1_588_992_600.0])
                         .labels(&["1588298471.0", "1588992600.0"]),
                 )
                 .y_axis(Axis::default().bounds([0.0, 1.0]).labels(&["0.0", "1.0"]))

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -73,7 +73,7 @@ fn it_should_truncate_items() {
         let items = case.items.drain(..);
         terminal
             .draw(|mut f| {
-                let list = List::new(items.into_iter())
+                let list = List::new(items)
                     .block(Block::default().borders(Borders::RIGHT))
                     .highlight_symbol(">> ");
                 f.render_stateful_widget(list, Rect::new(0, 0, 8, 2), &mut state);


### PR DESCRIPTION
- Remove deny warnings in lib.rs. This allows easier iteration when developing
new features. The warnings will make the CI fails anyway on the clippy CI
stage.
- Run clippy on all targets (including tests and examples) and all features.
- Fail CI on clippy warnings.