### PR TITLE
Fix build

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,6 +3,7 @@ use crate::{
     style::{Color, Modifier, Style},
 };
 use std::cmp::min;
+use std::usize;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 


### PR DESCRIPTION
When trying to compile master with rustc 1.41:

```
   Compiling tui v0.9.5 (/home/ma27/Projects/tui-rs)
error[E0599]: no associated item named `MAX` found for type `usize` in the current scope
   --> src/buffer.rs:259:47
    |
259 |         self.set_stringn(x, y, string, usize::MAX, style);
    |                                               ^^^ associated item not found in `usize`
    |
help: you are looking for the module in `std`, not the primitive type
    |
259 |         self.set_stringn(x, y, string, std::usize::MAX, style);
    |                                        ^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `tui`.

To learn more, run the command again with --verbose.
```