### PR TITLE
Control cursor position and visibility via Frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## To be released
 
+### Breaking Changes
+
+* `Terminal::draw()` now requires a closure that takes `&mut Frame`.
+
+### Features
+
 * Add feature-gated (`serde`) serialization of `Style`.
+* Add `Frame::set_cursor()` to dictate where the cursor should be placed after
+    the call to `Terminial::draw()`. Calling this method would also make the
+    cursor visible after the call to `draw()`. See example usage in
+    *examples/user_input.rs*.
 
 ## v0.9.5 - 2020-05-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Florian Dehau <work@fdehau.com>"]
 description = """
 A library to build rich terminal user interfaces or dashboards
 """
-documentation = "https://docs.rs/tui/0.9.5/tui/"
+documentation = "https://docs.rs/tui/0.10.0/tui/"
 keywords = ["tui", "terminal", "dashboard"]
 repository = "https://github.com/fdehau/tui-rs"
 license = "MIT"

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let events = Events::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             // Wrapping block for a group
             // Just draw the block and the group on the same area and build the group
             // with at least a margin of 1

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -92,7 +92,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let size = f.size();
             let chunks = Layout::default()
                 .direction(Direction::Vertical)

--- a/examples/crossterm_demo.rs
+++ b/examples/crossterm_demo.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.clear()?;
 
     loop {
-        terminal.draw(|mut f| ui::draw(&mut f, &mut app))?;
+        terminal.draw(|f| ui::draw(f, &mut app))?;
         match rx.recv()? {
             Event::Input(event) => match event.code {
                 KeyCode::Char('q') => {

--- a/examples/curses_demo.rs
+++ b/examples/curses_demo.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_tick = Instant::now();
     let tick_rate = Duration::from_millis(cli.tick_rate);
     loop {
-        terminal.draw(|mut f| ui::draw(&mut f, &mut app))?;
+        terminal.draw(|f| ui::draw(f, &mut app))?;
         if let Some(input) = terminal.backend_mut().get_curses_mut().get_input() {
             match input {
                 easycurses::Input::Character(c) => {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let events = Events::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let size = f.size();
             let label = Label::default().text("Test");
             f.render_widget(label, size);

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let events = Events::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints(

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -88,7 +88,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut scroll: u16 = 0;
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let size = f.size();
 
             // Words made "loooong" to demonstrate line breaking.

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let events = Events::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let size = f.size();
 
             let chunks = Layout::default()

--- a/examples/rustbox_demo.rs
+++ b/examples/rustbox_demo.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_tick = Instant::now();
     let tick_rate = Duration::from_millis(cli.tick_rate);
     loop {
-        terminal.draw(|mut f| ui::draw(&mut f, &mut app))?;
+        terminal.draw(|f| ui::draw(f, &mut app))?;
         if let Ok(rustbox::Event::KeyEvent(key)) =
             terminal.backend().rustbox().peek_event(tick_rate, false)
         {

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut app = App::new();
 
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -88,7 +88,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Input
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let rects = Layout::default()
                 .constraints([Constraint::Percentage(100)].as_ref())
                 .margin(5)

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Main loop
     loop {
-        terminal.draw(|mut f| {
+        terminal.draw(|f| {
             let size = f.size();
             let chunks = Layout::default()
                 .direction(Direction::Vertical)

--- a/examples/termion_demo.rs
+++ b/examples/termion_demo.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut app = App::new("Termion demo", cli.enhanced_graphics);
     loop {
-        terminal.draw(|mut f| ui::draw(&mut f, &mut app))?;
+        terminal.draw(|f| ui::draw(f, &mut app))?;
 
         match events.next()? {
             Event::Input(key) => match key {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //!     let stdout = io::stdout().into_raw_mode()?;
 //!     let backend = TermionBackend::new(stdout);
 //!     let mut terminal = Terminal::new(backend)?;
-//!     terminal.draw(|mut f| {
+//!     terminal.draw(|f| {
 //!         let size = f.size();
 //!         let block = Block::default()
 //!             .title("Block")
@@ -116,7 +116,7 @@
 //!     let stdout = io::stdout().into_raw_mode()?;
 //!     let backend = TermionBackend::new(stdout);
 //!     let mut terminal = Terminal::new(backend)?;
-//!     terminal.draw(|mut f| {
+//!     terminal.draw(|f| {
 //!         let chunks = Layout::default()
 //!             .direction(Direction::Vertical)
 //!             .margin(1)

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -184,7 +184,7 @@ pub trait Widget {
 /// ]);
 ///
 /// loop {
-///     terminal.draw(|mut f| {
+///     terminal.draw(|f| {
 ///         // The items managed by the application are transformed to something
 ///         // that is understood by tui.
 ///         let items = events.items.iter().map(Text::raw);

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -10,7 +10,7 @@ fn widgets_block_renders() {
     let backend = TestBackend::new(10, 10);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let block = Block::default()
                 .title("Title")
                 .borders(Borders::ALL)

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -13,7 +13,7 @@ fn widgets_chart_can_have_axis_with_zero_length_bounds() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let datasets = [Dataset::default()
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(Color::Magenta))
@@ -42,7 +42,7 @@ fn widgets_chart_handles_overflows() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let datasets = [Dataset::default()
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(Color::Magenta))
@@ -79,7 +79,7 @@ fn widgets_chart_can_have_empty_datasets() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let datasets = [Dataset::default().data(&[]).graph_type(Line)];
             let chart = Chart::default()
                 .block(

--- a/tests/widgets_gauge.rs
+++ b/tests/widgets_gauge.rs
@@ -11,7 +11,7 @@ fn widgets_gauge_renders() {
     let backend = TestBackend::new(40, 10);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -15,7 +15,7 @@ fn widgets_list_should_highlight_the_selected_item() {
     let mut state = ListState::default();
     state.select(Some(1));
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let size = f.size();
             let items = vec![
                 Text::raw("Item 1"),
@@ -71,7 +71,7 @@ fn widgets_list_should_truncate_items() {
         state.select(case.selected);
         let items = case.items.drain(..);
         terminal
-            .draw(|mut f| {
+            .draw(|f| {
                 let list = List::new(items)
                     .block(Block::default().borders(Borders::RIGHT))
                     .highlight_symbol(">> ");

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -18,7 +18,7 @@ fn widgets_paragraph_can_wrap_its_content() {
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|mut f| {
+            .draw(|f| {
                 let size = f.size();
                 let text = [Text::raw(SAMPLE_STRING)];
                 let paragraph = Paragraph::new(text.iter())
@@ -85,7 +85,7 @@ fn widgets_paragraph_renders_double_width_graphemes() {
 
     let s = "コンピュータ上で文字を扱う場合、典型的には文字による通信を行う場合にその両端点では、";
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let size = f.size();
             let text = [Text::raw(s)];
             let paragraph = Paragraph::new(text.iter())
@@ -117,7 +117,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
 
     let s = "aコンピュータ上で文字を扱う場合、";
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let size = f.size();
             let text = [Text::raw(s)];
             let paragraph = Paragraph::new(text.iter())

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -11,7 +11,7 @@ fn widgets_table_column_spacing_can_be_changed() {
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|mut f| {
+            .draw(|f| {
                 let size = f.size();
                 let table = Table::new(
                     ["Head1", "Head2", "Head3"].iter(),
@@ -112,7 +112,7 @@ fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|mut f| {
+            .draw(|f| {
                 let size = f.size();
                 let table = Table::new(
                     ["Head1", "Head2", "Head3"].iter(),
@@ -203,7 +203,7 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|mut f| {
+            .draw(|f| {
                 let size = f.size();
                 let table = Table::new(
                     ["Head1", "Head2", "Head3"].iter(),
@@ -312,7 +312,7 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
-            .draw(|mut f| {
+            .draw(|f| {
                 let size = f.size();
                 let table = Table::new(
                     ["Head1", "Head2", "Head3"].iter(),

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -5,7 +5,7 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
     let backend = TestBackend::new(1, 1);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let tabs = Tabs::default().titles(&["Tab1", "Tab2"]);
             f.render_widget(
                 tabs,
@@ -27,7 +27,7 @@ fn widgets_tabs_should_truncate_the_last_item() {
     let backend = TestBackend::new(10, 1);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|mut f| {
+        .draw(|f| {
             let tabs = Tabs::default().titles(&["Tab1", "Tab2"]);
             f.render_widget(
                 tabs,


### PR DESCRIPTION
This implements the idea I outlined in https://github.com/fdehau/tui-rs/issues/91#issuecomment-634998916:

> can't `Frame` have a field like `Option<(u16, u16)>`, which is the cursor's desired position after drawing the frame? `None` means the cursor is hidden, `Some` with a position means the cursor is shown and is positioned at the given cell.

The implementation deviates from the idea in two ways.

First of all, `Frame` is moved into the drawing closure — there is no way for `Terminal::draw()` to examine frame's fields afterwards. This could be resolved in two ways:

1. make `Terminal::draw()` require `FnOnce(&mut Frame<B>)`. This is very clean, but it's a breaking change, so I decided against that.

2. store that `Option<(u16, u16)>` in the `Terminal` itself, and make `Frame` just pass the calls through. That's a bit of a hack, because I don't think it's `Terminal`'s responsibility to store this data; it's `Frame`'s job to describe what has to be drawn and how.

The second option is a non-breaking change, so I went with that.

That decision led to the second deviation. `Terminal` already has an API for controlling the cursor: `hide_cursor()`, `show_cursor()`, `set_cursor()`. These calls have immediate effect on the terminal (modulo stdout buffering). This conflicts with the proposed API, and could be resolved in two ways:

1. make the old API non-public. This doesn't seem right to me, since `Terminal` is supposed to be a low-level wrapper around the backend.

2. make the new API opt-in. Up until the first call to `Frame::set_desired_cursor_position()`, calls to `draw()` don't affect cursor visibility, so the user is free to use `Terminal::hide_cursor()` and `Terminal::show_cursor()`. After the first call to the new API, however, the cursor position and visibility is always enforced after each `Terminal::draw()` call.

The first option is not viable, so I went with the second one.

I think that in the long term, tui-rs should change the signature of `Terminal::draw()`, to move all of this to `Frame`, and make `Terminal` a completely low-level thing again. If that's the plan, it might make sense to make the new API on `Terminal` non-public now, so people don't depend on what is going to be removed. @fdehau, I'm also okay with re-doing the PR to change the signature now, if you're ok with a breaking change.