### PR TITLE
Constrain width and height to be non-negative in split().

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -464,6 +464,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_vertical_split_by_height() {
+        let target = Rect {
+            x: 2,
+            y: 2,
+            width: 10,
+            height: 10,
+        };
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Percentage(10),
+                    Constraint::Max(5),
+                    Constraint::Min(1),
+                ]
+                .as_ref(),
+            )
+            .split(target);
+
+        assert_eq!(target.height, chunks.iter().map(|r| r.height).sum::<u16>());
+        chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));
+    }
+
+    #[test]
     fn test_rect_size_truncation() {
         for width in 256u16..300u16 {
             for height in 256u16..300u16 {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -209,6 +209,8 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
     let mut ccs: Vec<CassowaryConstraint> =
         Vec::with_capacity(elements.len() * 4 + layout.constraints.len() * 6);
     for elt in &elements {
+        ccs.push(elt.width | GE(REQUIRED) | 0f64);
+        ccs.push(elt.height | GE(REQUIRED) | 0f64);
         ccs.push(elt.left() | GE(REQUIRED) | f64::from(dest_area.left()));
         ccs.push(elt.top() | GE(REQUIRED) | f64::from(dest_area.top()));
         ccs.push(elt.right() | LE(REQUIRED) | f64::from(dest_area.right()));


### PR DESCRIPTION
I implemented a Cassowary constraint solver in Go (which may be found [here](https://github.com/lithdew/casso)) and re-wrote `split()` in Go for vertical layouts just as a test case [here](https://gist.github.com/lithdew/250fde08aa4e08ce4211f74365268e17).

I got better numerical stability by constraining the width and heights of elements to be >= 0. Take for example the input:

```go
{
	input: Rect{x: 2, y: 2, w: 10, h: 10},
	params: []Constraint{Percentage(10), Max(5), Min(1)},
	expected: []Rect{
		{x: 2, y: 2, w: 10, h: 1},
		{x: 2, y: 3, w: 10, h: 5},
		{x: 2, y: 8, w: 10, h: 4},
	},
}
```

Without the patch in this PR, I got malformed regions.

The third `Rect` in the output below is of height 10, which is as a result of the constraint solver erroneously positioning the third rectangle to overlap with the first rectangle.

```
Rect {
	x: 2,
	y: 2,
	width: 10,
	height: 1,
},
Rect {
	x: 2,
	y: 3,
	width: 10,
	height: 0,
},
Rect {
	x: 2,
	y: 2,
	width: 10,
	height: 10,
},
```

With this patch, the constraint solver is able to optimize for filling up the space of the specified area rectangle s.t. the positions of rectangles do not overlap and that widths/height constraints are respected.

```
Rect {
	x: 2,
	y: 2,
	width: 10,
	height: 1,
},
Rect {
	x: 2,
	y: 3,
	width: 10,
	height: 0,
},
Rect {
	x: 2,
	y: 3,
	width: 10,
	height: 9,
},
```

The test used to debug this was to call split() multiple times; clearin gout the layout cache before each and every call.

```rust
#[test]
fn test_split_case1() {
    for i in 0..5 {
        let chunks = Layout::default()
            .direction(Direction::Vertical)
            .constraints(
                [
                    Constraint::Percentage(10),
                    Constraint::Max(5),
                    Constraint::Min(1),
                ]
                .as_ref(),
            )
            .split(Rect {
                x: 2,
                y: 2,
                width: 10,
                height: 10,
            });

        LAYOUT_CACHE.with(|cache| {
            cache.borrow_mut().clear();
        });

        dbg!(chunks);
    }
}
```