### PR TITLE
Added margins to tabs widget

### DIFF
--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .highlight_style(Style::default().fg(Color::Yellow))
                 .margin(Margin {
                     vertical: 0,
-                    horizontal: 2,
+                    horizontal: 1,
                 });
             f.render_widget(tabs, chunks[0]);
             let inner = match app.tabs.index {

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -53,10 +53,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .select(app.tabs.index)
                 .style(Style::default().fg(Color::Cyan))
                 .highlight_style(Style::default().fg(Color::Yellow))
-                .margin(Margin {
-                    vertical: 0,
-                    horizontal: 1,
-                });
+                .margin(Margin::default().horizontal(1));
             f.render_widget(tabs, chunks[0]);
             let inner = match app.tabs.index {
                 0 => Block::default().title("Inner 0").borders(Borders::ALL),

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -52,7 +52,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .titles(&app.tabs.titles)
                 .select(app.tabs.index)
                 .style(Style::default().fg(Color::Cyan))
-                .highlight_style(Style::default().fg(Color::Yellow));
+                .highlight_style(Style::default().fg(Color::Yellow))
+                .margin(2);
             f.render_widget(tabs, chunks[0]);
             let inner = match app.tabs.index {
                 0 => Block::default().title("Inner 0").borders(Borders::ALL),

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -9,7 +9,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Margin},
     style::{Color, Style},
     widgets::{Block, Borders, Tabs},
     Terminal,
@@ -53,7 +53,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .select(app.tabs.index)
                 .style(Style::default().fg(Color::Cyan))
                 .highlight_style(Style::default().fg(Color::Yellow))
-                .margin(2);
+                .margin(Margin {
+                    vertical: 0,
+                    horizontal: 2,
+                });
             f.render_widget(tabs, chunks[0]);
             let inner = match app.tabs.index {
                 0 => Block::default().title("Inner 0").borders(Borders::ALL),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -51,6 +51,33 @@ pub struct Margin {
     pub horizontal: u16,
 }
 
+impl Margin {
+    pub fn both(mut self, margin: u16) -> Self {
+        self.vertical = margin;
+        self.horizontal = margin;
+        self
+    }
+
+    pub fn horizontal(mut self, margin: u16) -> Self {
+        self.horizontal = margin;
+        self
+    }
+
+    pub fn vertical(mut self, margin: u16) -> Self {
+        self.vertical = margin;
+        self
+    }
+}
+
+impl Default for Margin {
+    fn default() -> Self {
+        Margin {
+            vertical: 0,
+            horizontal: 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Alignment {
     Left,

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -116,14 +116,9 @@ where
         }
         .inner(&self.margin);
 
-        println!("area: {:?}, tabs_area: {:?}", area, tabs_area);
-        println!("tabs_area height: {}", tabs_area.height);
-
         if tabs_area.height < 1 {
             return;
         }
-
-        println!("didn't return");
 
         buf.set_background(tabs_area, self.style.bg);
 

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -116,9 +116,14 @@ where
         }
         .inner(&self.margin);
 
+        println!("area: {:?}, tabs_area: {:?}", area, tabs_area);
+        println!("tabs_area height: {}", tabs_area.height);
+
         if tabs_area.height < 1 {
             return;
         }
+
+        println!("didn't return");
 
         buf.set_background(tabs_area, self.style.bg);
 

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -38,6 +38,8 @@ where
     highlight_style: Style,
     /// Tab divider
     divider: &'a str,
+    /// Margin width
+    margin: u16,
 }
 
 impl<'a, T> Default for Tabs<'a, T>
@@ -52,6 +54,7 @@ where
             style: Default::default(),
             highlight_style: Default::default(),
             divider: line::VERTICAL,
+            margin: 0,
         }
     }
 }
@@ -89,6 +92,11 @@ where
         self.divider = divider;
         self
     }
+
+    pub fn margin(mut self, margin: u16) -> Tabs<'a, T> {
+        self.margin = margin;
+        self
+    }
 }
 
 impl<'a, T> Widget for Tabs<'a, T>
@@ -113,15 +121,25 @@ where
         let mut x = tabs_area.left();
         let titles_length = self.titles.len();
         let divider_width = self.divider.width() as u16;
-        for (title, style, last_title) in self.titles.iter().enumerate().map(|(i, t)| {
-            let lt = i + 1 == titles_length;
-            if i == self.selected {
-                (t, self.highlight_style, lt)
+        for (title, style, first_title, last_title) in
+            self.titles.iter().enumerate().map(|(i, t)| {
+                let lt = i + 1 == titles_length;
+                let ft = i == 0;
+                if i == self.selected {
+                    (t, self.highlight_style, ft, lt)
+                } else {
+                    (t, self.style, ft, lt)
+                }
+            })
+        {
+            if first_title {
+                // Adds left margin on first title
+                x += self.margin;
             } else {
-                (t, self.style, lt)
+                // Adds one space between titles
+                x += 1;
             }
-        }) {
-            x += 1;
+
             if x >= tabs_area.right() {
                 break;
             } else {

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -18,13 +18,15 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
             );
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec![" "]);
+
+    // FIXME: Assumes 0-wide margin when not explicity specified
+    let expected = Buffer::with_lines(vec!["T"]);
     terminal.backend().assert_buffer(&expected);
 }
 
 #[test]
 fn widgets_tabs_should_truncate_the_last_item() {
-    let backend = TestBackend::new(10, 1);
+    let backend = TestBackend::new(9, 1);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|mut f| {
@@ -34,12 +36,42 @@ fn widgets_tabs_should_truncate_the_last_item() {
                 Rect {
                     x: 0,
                     y: 0,
-                    width: 9,
+                    width: 8,
                     height: 1,
                 },
             );
         })
         .unwrap();
-    let expected = Buffer::with_lines(vec![format!(" Tab1 {} Ta", symbols::line::VERTICAL)]);
+
+    // FIXME: Assumes 0-wide margin when not explicitly specified
+    // FIXME: Assumes VERTICAL divider when not explicity specified
+    // if default divider changes test will fail
+    let expected = Buffer::with_lines(vec![format!("Tab1 {} Ta", symbols::line::VERTICAL)]);
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_tabs_should_respect_left_margin() {
+    // TODO: Possibly test other number of margins
+    let backend = TestBackend::new(13, 1);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|mut f| {
+            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]).margin(2);
+            f.render_widget(
+                tabs,
+                Rect {
+                    x: 0,
+                    y: 0,
+                    width: 13,
+                    height: 1,
+                },
+            );
+        })
+        .unwrap();
+
+    // FIXME: Assumes VERTICAL divider when not explicity specified
+    // if default divider changes test will fail
+    let expected = Buffer::with_lines(vec![format!("  Tab1 {} Tab2", symbols::line::VERTICAL)]);
     terminal.backend().assert_buffer(&expected);
 }

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -6,7 +6,7 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|mut f| {
-            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]);
+            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]).margin(0);
             f.render_widget(
                 tabs,
                 Rect {
@@ -19,7 +19,6 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
         })
         .unwrap();
 
-    // FIXME: Assumes 0-wide margin when not explicity specified
     let expected = Buffer::with_lines(vec!["T"]);
     terminal.backend().assert_buffer(&expected);
 }
@@ -30,7 +29,10 @@ fn widgets_tabs_should_truncate_the_last_item() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|mut f| {
-            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]);
+            let tabs = Tabs::default()
+                .titles(&["Tab1", "Tab2"])
+                .margin(0)
+                .divider(symbols::line::VERTICAL);
             f.render_widget(
                 tabs,
                 Rect {
@@ -43,9 +45,6 @@ fn widgets_tabs_should_truncate_the_last_item() {
         })
         .unwrap();
 
-    // FIXME: Assumes 0-wide margin when not explicitly specified
-    // FIXME: Assumes VERTICAL divider when not explicity specified
-    // if default divider changes test will fail
     let expected = Buffer::with_lines(vec![format!("Tab1 {} Ta", symbols::line::VERTICAL)]);
     terminal.backend().assert_buffer(&expected);
 }
@@ -57,7 +56,10 @@ fn widgets_tabs_should_respect_left_margin() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|mut f| {
-            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]).margin(2);
+            let tabs = Tabs::default()
+                .titles(&["Tab1", "Tab2"])
+                .margin(2)
+                .divider(symbols::line::VERTICAL);
             f.render_widget(
                 tabs,
                 Rect {
@@ -70,8 +72,6 @@ fn widgets_tabs_should_respect_left_margin() {
         })
         .unwrap();
 
-    // FIXME: Assumes VERTICAL divider when not explicity specified
-    // if default divider changes test will fail
     let expected = Buffer::with_lines(vec![format!("  Tab1 {} Tab2", symbols::line::VERTICAL)]);
     terminal.backend().assert_buffer(&expected);
 }

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -166,3 +166,69 @@ fn widgets_tabs_should_respect_right_margin() {
     test_case(3, 10, "   Tab1   ".to_string());
     test_case(3, 6, "      ".to_string());
 }
+
+#[test]
+fn widgets_tabs_should_respect_vertical_margin() {
+    let test_case = |margin, height, expected_buf: Vec<String>| {
+        let backend = TestBackend::new(11, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|mut f| {
+                let tabs = Tabs::default()
+                    .titles(&["Tab1", "Tab2"])
+                    .margin(Margin {
+                        horizontal: 0,
+                        vertical: margin,
+                    })
+                    .divider(symbols::line::VERTICAL);
+
+                f.render_widget(
+                    tabs,
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: 11,
+                        height,
+                    },
+                );
+            })
+            .unwrap();
+
+        let expected = Buffer::with_lines(expected_buf);
+        terminal.backend().assert_buffer(&expected);
+    };
+
+    test_case(0, 1, vec![format!("Tab1 {} Tab2", symbols::line::VERTICAL)]);
+    test_case(
+        1,
+        3,
+        vec![
+            " ".repeat(11),
+            format!("Tab1 {} Tab2", symbols::line::VERTICAL),
+            " ".repeat(11),
+        ],
+    );
+    test_case(
+        2,
+        5,
+        vec![
+            " ".repeat(11),
+            " ".repeat(11),
+            format!("Tab1 {} Tab2", symbols::line::VERTICAL),
+            " ".repeat(11),
+            " ".repeat(11),
+        ],
+    );
+    test_case(1, 2, vec![" ".repeat(11), " ".repeat(11)]);
+    test_case(
+        2,
+        4,
+        vec![
+            " ".repeat(11),
+            " ".repeat(11),
+            " ".repeat(11),
+            " ".repeat(11),
+        ],
+    );
+    test_case(2, 3, vec![" ".repeat(11), " ".repeat(11), " ".repeat(11)]);
+}

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -1,4 +1,11 @@
-use tui::{backend::TestBackend, buffer::Buffer, layout::Rect, symbols, widgets::Tabs, Terminal};
+use tui::{
+    backend::TestBackend,
+    buffer::Buffer,
+    layout::{Margin, Rect},
+    symbols,
+    widgets::Tabs,
+    Terminal,
+};
 
 #[test]
 fn widgets_tabs_should_not_panic_on_narrow_areas() {
@@ -6,7 +13,10 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|mut f| {
-            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]).margin(0);
+            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]).margin(Margin {
+                horizontal: 0,
+                vertical: 0,
+            });
             f.render_widget(
                 tabs,
                 Rect {
@@ -31,7 +41,10 @@ fn widgets_tabs_should_truncate_the_last_item() {
         .draw(|mut f| {
             let tabs = Tabs::default()
                 .titles(&["Tab1", "Tab2"])
-                .margin(0)
+                .margin(Margin {
+                    horizontal: 0,
+                    vertical: 0,
+                })
                 .divider(symbols::line::VERTICAL);
             f.render_widget(
                 tabs,
@@ -57,7 +70,10 @@ fn widgets_tabs_should_not_panic_on_narrow_areas_with_margin() {
         .draw(|mut f| {
             let tabs = Tabs::default()
                 .titles(&["Tab1", "Tab2"])
-                .margin(3)
+                .margin(Margin {
+                    horizontal: 3,
+                    vertical: 0,
+                })
                 .divider(symbols::line::VERTICAL);
             f.render_widget(
                 tabs,
@@ -84,7 +100,10 @@ fn widgets_tabs_should_respect_left_margin() {
             .draw(|mut f| {
                 let tabs = Tabs::default()
                     .titles(&["Tab1", "Tab2"])
-                    .margin(margin)
+                    .margin(Margin {
+                        horizontal: margin,
+                        vertical: 0,
+                    })
                     .divider(symbols::line::VERTICAL);
                 f.render_widget(
                     tabs,
@@ -120,7 +139,10 @@ fn widgets_tabs_should_respect_right_margin() {
             .draw(|mut f| {
                 let tabs = Tabs::default()
                     .titles(&["Tab1", "Tab2"])
-                    .margin(margin)
+                    .margin(Margin {
+                        horizontal: margin,
+                        vertical: 0,
+                    })
                     .divider(symbols::line::VERTICAL);
                 f.render_widget(
                     tabs,

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -13,10 +13,9 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|mut f| {
-            let tabs = Tabs::default().titles(&["Tab1", "Tab2"]).margin(Margin {
-                horizontal: 0,
-                vertical: 0,
-            });
+            let tabs = Tabs::default()
+                .titles(&["Tab1", "Tab2"])
+                .margin(Margin::default());
             f.render_widget(
                 tabs,
                 Rect {
@@ -41,10 +40,7 @@ fn widgets_tabs_should_truncate_the_last_item() {
         .draw(|mut f| {
             let tabs = Tabs::default()
                 .titles(&["Tab1", "Tab2"])
-                .margin(Margin {
-                    horizontal: 0,
-                    vertical: 0,
-                })
+                .margin(Margin::default())
                 .divider(symbols::line::VERTICAL);
             f.render_widget(
                 tabs,
@@ -70,10 +66,7 @@ fn widgets_tabs_should_not_panic_on_narrow_areas_with_margin() {
         .draw(|mut f| {
             let tabs = Tabs::default()
                 .titles(&["Tab1", "Tab2"])
-                .margin(Margin {
-                    horizontal: 3,
-                    vertical: 0,
-                })
+                .margin(Margin::default().horizontal(3))
                 .divider(symbols::line::VERTICAL);
             f.render_widget(
                 tabs,
@@ -100,10 +93,7 @@ fn widgets_tabs_should_respect_left_margin() {
             .draw(|mut f| {
                 let tabs = Tabs::default()
                     .titles(&["Tab1", "Tab2"])
-                    .margin(Margin {
-                        horizontal: margin,
-                        vertical: 0,
-                    })
+                    .margin(Margin::default().horizontal(margin))
                     .divider(symbols::line::VERTICAL);
                 f.render_widget(
                     tabs,
@@ -139,10 +129,7 @@ fn widgets_tabs_should_respect_right_margin() {
             .draw(|mut f| {
                 let tabs = Tabs::default()
                     .titles(&["Tab1", "Tab2"])
-                    .margin(Margin {
-                        horizontal: margin,
-                        vertical: 0,
-                    })
+                    .margin(Margin::default().horizontal(margin))
                     .divider(symbols::line::VERTICAL);
                 f.render_widget(
                     tabs,
@@ -176,10 +163,7 @@ fn widgets_tabs_should_respect_vertical_margin() {
             .draw(|mut f| {
                 let tabs = Tabs::default()
                     .titles(&["Tab1", "Tab2"])
-                    .margin(Margin {
-                        horizontal: 0,
-                        vertical: margin,
-                    })
+                    .margin(Margin::default().vertical(margin))
                     .divider(symbols::line::VERTICAL);
 
                 f.render_widget(


### PR DESCRIPTION
Closes #299 

Margins can now be added to the tabs widget by using the `Margin` struct, which was previously used for margins between blocks I believe. The [`tabs.rs` example was updated to reflect this](https://github.com/thorlucas/tui-rs/blob/af2f0d47b1e4d4a7ca1a177e1c10d4c9aa5fd53f/examples/tabs.rs#L56).

The `vertical` field sets the margins/padding on the top and bottom of the widget, while the `horizontal` on the left and right. The tabs widget will be trimmed if these margins would push the contents off the screen. For example, setting vertical margins to 1 on a 2-line-tall tabs widget would display nothing, as the two lines would be used as margins.

The margins can be set with a `.margin(...)` builder method on the tabs widget.

Builder methods were also added for the `Margin` struct to facilitate creation. The `Margin::default()` sets both to zero, as is the visual default for other widgets, while the `Margin::default().horizontal(x)` and `.vertical(x)` builder methods set the horizontal and vertical components. `.both(xy)` sets both vertical and horizontal components to the same number.

Several new tests were added to the `widgets_tabs.rs` to ensure that the widget respects horizontal and vertical margins in a variety of cases.

Note that margins will still need to be added to other widgets in able to behave consistently with the new style of adding margins (`.margin(...)` with a `Margin` struct). These will be submitted as separate PRs.