### PR TITLE
Add scroll horizontally support for paragraph

### DIFF
--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -82,7 +82,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .block(block.clone().title("Center, wrap"))
                 .alignment(Alignment::Center)
                 .wrap(true)
-                .scroll(scroll);
+                .scroll((scroll, 0));
             f.render_widget(paragraph, chunks[2]);
             let paragraph = Paragraph::new(text.iter())
                 .block(block.clone().title("Right, wrap"))

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -136,7 +136,11 @@ where
         let mut line_composer: Box<dyn LineComposer> = if self.wrapping {
             Box::new(WordWrapper::new(&mut styled, text_area.width))
         } else {
-            Box::new(LineTruncator::new(&mut styled, text_area.width, self.scroll.1))
+            Box::new(LineTruncator::new(
+                &mut styled,
+                text_area.width,
+                self.scroll.1,
+            ))
         };
         let mut y = 0;
         while let Some((current_line, current_line_width)) = line_composer.next_line() {
@@ -144,11 +148,7 @@ where
                 let mut x = get_line_offset(current_line_width, text_area.width, self.alignment);
                 for Styled(symbol, style) in current_line {
                     buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll.0)
-                        .set_symbol(if symbol.is_empty() {
-                            " "
-                        } else {
-                            symbol
-                        })
+                        .set_symbol(if symbol.is_empty() { " " } else { symbol })
                         .set_style(*style);
                     x += symbol.width() as u16;
                 }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -139,7 +139,10 @@ where
             Box::new(LineTruncator::new(
                 &mut styled,
                 text_area.width,
-                self.scroll.1,
+                match self.alignment {
+                    Alignment::Left => self.scroll.1, // only support Alignment::Left
+                    _ => 0,
+                },
             ))
         };
         let mut y = 0;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -148,7 +148,13 @@ where
                 let mut x = get_line_offset(current_line_width, text_area.width, self.alignment);
                 for Styled(symbol, style) in current_line {
                     buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll.0)
-                        .set_symbol(if symbol.is_empty() { " " } else { symbol })
+                        .set_symbol(if symbol.is_empty() {
+                            // If the symbol is empty, the last char which rendered last time will
+                            // leave on the line. It's a quick fix.
+                            " "
+                        } else {
+                            symbol
+                        })
                         .set_style(*style);
                     x += symbol.width() as u16;
                 }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -144,7 +144,11 @@ where
                 let mut x = get_line_offset(current_line_width, text_area.width, self.alignment);
                 for Styled(symbol, style) in current_line {
                     buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll.0)
-                        .set_symbol(symbol)
+                        .set_symbol(if symbol.is_empty() {
+                            " "
+                        } else {
+                            symbol
+                        })
                         .set_style(*style);
                     x += symbol.width() as u16;
                 }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -50,7 +50,7 @@ where
     /// Should we parse the text for embedded commands
     raw: bool,
     /// Scroll
-    scroll: u16,
+    scroll: (u16, u16),
     /// Aligenment of the text
     alignment: Alignment,
 }
@@ -66,7 +66,7 @@ where
             wrapping: false,
             raw: false,
             text,
-            scroll: 0,
+            scroll: (0, 0),
             alignment: Alignment::Left,
         }
     }
@@ -91,7 +91,7 @@ where
         self
     }
 
-    pub fn scroll(mut self, offset: u16) -> Paragraph<'a, 't, T> {
+    pub fn scroll(mut self, offset: (u16, u16)) -> Paragraph<'a, 't, T> {
         self.scroll = offset;
         self
     }
@@ -136,21 +136,21 @@ where
         let mut line_composer: Box<dyn LineComposer> = if self.wrapping {
             Box::new(WordWrapper::new(&mut styled, text_area.width))
         } else {
-            Box::new(LineTruncator::new(&mut styled, text_area.width))
+            Box::new(LineTruncator::new(&mut styled, text_area.width, self.scroll.1))
         };
         let mut y = 0;
         while let Some((current_line, current_line_width)) = line_composer.next_line() {
-            if y >= self.scroll {
+            if y >= self.scroll.0 {
                 let mut x = get_line_offset(current_line_width, text_area.width, self.alignment);
                 for Styled(symbol, style) in current_line {
-                    buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll)
+                    buf.get_mut(text_area.left() + x, text_area.top() + y - self.scroll.0)
                         .set_symbol(symbol)
                         .set_style(*style);
                     x += symbol.width() as u16;
                 }
             }
             y += 1;
-            if y >= text_area.height + self.scroll {
+            if y >= text_area.height + self.scroll.0 {
                 break;
             }
         }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -137,11 +137,8 @@ where
             Box::new(WordWrapper::new(&mut styled, text_area.width))
         } else {
             let mut line_composer = Box::new(LineTruncator::new(&mut styled, text_area.width));
-            match self.alignment {
-                Alignment::Left => {
-                    line_composer.set_horizontal_offset(self.scroll.1);
-                }
-                _ => {}
+            if let Alignment::Left = self.alignment {
+                line_composer.set_horizontal_offset(self.scroll.1);
             }
             line_composer
         };

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -136,14 +136,14 @@ where
         let mut line_composer: Box<dyn LineComposer> = if self.wrapping {
             Box::new(WordWrapper::new(&mut styled, text_area.width))
         } else {
-            Box::new(LineTruncator::new(
-                &mut styled,
-                text_area.width,
-                match self.alignment {
-                    Alignment::Left => self.scroll.1, // only support Alignment::Left
-                    _ => 0,
-                },
-            ))
+            let mut line_composer = Box::new(LineTruncator::new(&mut styled, text_area.width));
+            match self.alignment {
+                Alignment::Left => {
+                    line_composer.set_horizontal_offset(self.scroll.1);
+                }
+                _ => {}
+            }
+            line_composer
         };
         let mut y = 0;
         while let Some((current_line, current_line_width)) = line_composer.next_line() {

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -221,7 +221,9 @@ mod test {
         let mut styled = UnicodeSegmentation::graphemes(text, true).map(|g| Styled(g, style));
         let mut composer: Box<dyn LineComposer> = match which {
             Composer::WordWrapper => Box::new(WordWrapper::new(&mut styled, text_area_width)),
-            Composer::LineTruncator => Box::new(LineTruncator::new(&mut styled, text_area_width, 0)),
+            Composer::LineTruncator => {
+                Box::new(LineTruncator::new(&mut styled, text_area_width, 0))
+            }
         };
         let mut lines = vec![];
         let mut widths = vec![];

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -139,3 +139,63 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
     ]);
     terminal.backend().assert_buffer(&expected);
 }
+
+#[test]
+fn widgets_paragraph_can_scroll_horizontally() {
+    let test_case = |alignment, scroll, expected| {
+        let backend = TestBackend::new(20, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|f| {
+                let size = f.size();
+                let text = [Text::raw(
+                    "段落现在可以水平滚动了！
+Paragraph can scroll horizontally!
+Short line
+",
+                )];
+                let paragraph = Paragraph::new(text.iter())
+                    .block(Block::default().borders(Borders::ALL))
+                    .alignment(alignment)
+                    .scroll(scroll);
+                f.render_widget(paragraph, size);
+            })
+            .unwrap();
+        terminal.backend().assert_buffer(&expected);
+    };
+
+    test_case(
+        Alignment::Left,
+        (0, 7),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│在可以水平滚动了！│",
+            "│ph can scroll hori│",
+            "│ine               │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+    // only support Alignment::Left
+    test_case(
+        Alignment::Right,
+        (0, 7),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│段落现在可以水平滚│",
+            "│Paragraph can scro│",
+            "│        Short line│",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+}


### PR DESCRIPTION
Now Paragraph can scroll horizontally
```rust
let p = Paragraph::new(items)
    .block(
        Block::default()
    )
    .scroll((0, 7));
```

```
+------------------------------+
|hello world                   |
+------------------------------+
```

```
+------------------------------+
|orld                          |
+------------------------------+
```