### PR TITLE
Don't destroy all newlines in Spans

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -172,11 +172,10 @@ impl<'a> Span<'a> {
         &'a self,
         base_style: Style,
     ) -> impl Iterator<Item = StyledGrapheme<'a>> {
-        UnicodeSegmentation::graphemes(self.content.as_ref(), true)
-            .map(move |g| StyledGrapheme {
-                symbol: g,
-                style: base_style.patch(self.style),
-            })
+        UnicodeSegmentation::graphemes(self.content.as_ref(), true).map(move |g| StyledGrapheme {
+            symbol: g,
+            style: base_style.patch(self.style),
+        })
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -177,7 +177,6 @@ impl<'a> Span<'a> {
                 symbol: g,
                 style: base_style.patch(self.style),
             })
-            .filter(|s| s.symbol != "\n")
     }
 }
 


### PR DESCRIPTION
This is the one-line fix to #339, but it was obviously there intentionally, so I'm open to discussing the merits of forcing the `Text` abstraction as the way to do multiple lines.

It's just that the current version makes applying one style to several lines much more difficult than it should be and makes double newlines extra messy.

Additionally, I've not tested it on Windows, but how does this newline filtering work on DOS files with the \r\n line ending?