### PR TITLE
Fixed compilation error regarding a lack of std:: before usize::MAX

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -263,7 +263,7 @@ impl Buffer {
     where
         S: AsRef<str>,
     {
-        self.set_stringn(x, y, string, usize::MAX, style);
+        self.set_stringn(x, y, string, std::usize::MAX, style);
     }
 
     /// Print at most the first n characters of a string if enough space is available


### PR DESCRIPTION
On Windows 10, trying to create a TUI application but I get a compilation error in v0.10.0 as follows:

PS C:\Users\JT\Documents\Rust Projects\tui> cargo run
   Compiling tui v0.10.0
error[E0599]: no associated item named `MAX` found for type `usize` in the current scope
   --> C:\Users\JT\.cargo\registry\src\github.com-1ecc6299db9ec823\tui-0.10.0\src\buffer.rs:266:47
    |
266 |         self.set_stringn(x, y, string, usize::MAX, style);
    |                                               ^^^ associated item not found in `usize`
help: you are looking for the module in `std`, not the primitive type
    |
266 |         self.set_stringn(x, y, string, std::usize::MAX, style);
    |    

so I changed the source and tested my fork as a local crate and it passes.