### PR TITLE
chore: document rustc min version supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: ["1.44.0", "stable"]
     steps:
       - name: "Install dependencies"
         run: sudo apt-get install libncurses5-dev
@@ -13,7 +16,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: "Format"
         uses: actions-rs/cargo@v1
@@ -52,12 +55,15 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    strategy:
+      matrix:
+        rust: ["1.44.0", "stable"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: "Check (crossterm)"
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ comes from the terminal emulator than the library itself.
 Moreover, the library does not provide any input handling nor any event system and
 you may rely on the previously cited libraries to achieve such features.
 
+### Rust version requirements
+
+Since version 0.10.0, `tui` requires **rustc version 1.44.0 or greater**.
+
 ### [Documentation](https://docs.rs/tui)
 
 ### Demo


### PR DESCRIPTION
- Add section to README
- Run ci tests with this min version in addition of stable to track changes that would require a min
rustc version bump.