### PR TITLE
feat(terminal): add unstable api to use a fixed viewport

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,4 +154,4 @@ pub mod terminal;
 pub mod text;
 pub mod widgets;
 
-pub use self::terminal::{Frame, Terminal};
+pub use self::terminal::{Frame, Terminal, TerminalOptions, Viewport};


### PR DESCRIPTION
There was now way to avoid the autoresize behavior of `Terminal`. While it was fine for most users,
it made the testing experience painful as it was impossible to avoid the calls to `Backend::size()`.
Indeed they trigger the following error: "Inappropriate ioctl for device" since we are not running
the tests in a real terminal (at least in the CI).

This commit introduces a new api to create a `Terminal` with a fixed viewport.