### PR TITLE
feat(widgets/paragraph): improve scrolling

### DIFF
--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -274,7 +274,7 @@ where
             .fg(Color::Magenta)
             .add_modifier(Modifier::BOLD),
     ));
-    let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
+    let paragraph = Paragraph::new(text).block(block).wrap(Wrap::default());
     f.render_widget(paragraph, area);
 }
 

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -81,20 +81,20 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .style(Style::default().bg(Color::White).fg(Color::Black))
                 .block(create_block("Left, wrap"))
                 .alignment(Alignment::Left)
-                .wrap(Wrap { trim: true });
+                .wrap(Wrap::default());
             f.render_widget(paragraph, chunks[1]);
             let paragraph = Paragraph::new(text.clone())
                 .style(Style::default().bg(Color::White).fg(Color::Black))
                 .block(create_block("Center, wrap"))
                 .alignment(Alignment::Center)
-                .wrap(Wrap { trim: true })
+                .wrap(Wrap::default())
                 .scroll((scroll, 0));
             f.render_widget(paragraph, chunks[2]);
             let paragraph = Paragraph::new(text)
                 .style(Style::default().bg(Color::White).fg(Color::Black))
                 .block(create_block("Right, wrap"))
                 .alignment(Alignment::Right)
-                .wrap(Wrap { trim: true });
+                .wrap(Wrap::default());
             f.render_widget(paragraph, chunks[3]);
         })?;
 

--- a/examples/paragraph2.rs
+++ b/examples/paragraph2.rs
@@ -1,0 +1,81 @@
+#[allow(dead_code)]
+mod util;
+
+use crate::util::event::{Event, Events};
+use std::{error::Error, io};
+use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
+use tui::{
+    backend::TermionBackend,
+    layout::{Alignment, Margin},
+    style::{Color, Style},
+    text::{Span, Spans},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Terminal,
+};
+
+const LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Terminal initialization
+    let stdout = io::stdout().into_raw_mode()?;
+    let stdout = MouseTerminal::from(stdout);
+    let stdout = AlternateScreen::from(stdout);
+    let backend = TermionBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let events = Events::new();
+
+    let mut i = 0;
+    let mut lines = Vec::with_capacity(100);
+    while i < 100 {
+        lines.push((i, format!("{}: {}", i, LOREM_IPSUM)));
+        i += 1;
+    }
+    loop {
+        terminal.draw(|f| {
+            let size = f.size();
+            let text: Vec<Spans> = lines
+                .iter()
+                .cloned()
+                .map(|(j, l)| {
+                    let span = if i == j + 1 {
+                        Span::styled(l, Style::default().bg(Color::Yellow))
+                    } else {
+                        Span::raw(l)
+                    };
+                    Spans::from(span)
+                })
+                .collect();
+            let mut wrap = Wrap::default();
+            wrap.scroll_callback = Some(Box::new(|text_area, lines| {
+                let len = lines.len() as u16;
+                (len.saturating_sub(text_area.height), 0)
+            }));
+            let paragraph = Paragraph::new(text)
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(wrap)
+                .alignment(Alignment::Left);
+            f.render_widget(
+                paragraph,
+                size.inner(&Margin {
+                    vertical: 2,
+                    horizontal: 2,
+                }),
+            );
+        })?;
+
+        match events.next()? {
+            Event::Tick => {
+                lines.push((i, format!("{}: {}", i, LOREM_IPSUM)));
+                lines.remove(0);
+                i += 1;
+            }
+            Event::Input(key) => {
+                if key == Key::Char('q') {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -81,12 +81,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let paragraph = Paragraph::new(text.clone())
                 .block(Block::default().title("Left Block").borders(Borders::ALL))
-                .alignment(Alignment::Left).wrap(Wrap { trim: true });
+                .alignment(Alignment::Left).wrap(Wrap::default());
             f.render_widget(paragraph, chunks[0]);
 
             let paragraph = Paragraph::new(text)
                 .block(Block::default().title("Right Block").borders(Borders::ALL))
-                .alignment(Alignment::Left).wrap(Wrap { trim: true });
+                .alignment(Alignment::Left).wrap(Wrap::default());
             f.render_widget(paragraph, chunks[1]);
 
             let block = Block::default().title("Popup").borders(Borders::ALL);

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -25,7 +25,7 @@ fn widgets_paragraph_can_wrap_its_content() {
                 let paragraph = Paragraph::new(text)
                     .block(Block::default().borders(Borders::ALL))
                     .alignment(alignment)
-                    .wrap(Wrap { trim: true });
+                    .wrap(Wrap::default());
                 f.render_widget(paragraph, size);
             })
             .unwrap();
@@ -91,7 +91,7 @@ fn widgets_paragraph_renders_double_width_graphemes() {
             let text = vec![Spans::from(s)];
             let paragraph = Paragraph::new(text)
                 .block(Block::default().borders(Borders::ALL))
-                .wrap(Wrap { trim: true });
+                .wrap(Wrap::default());
             f.render_widget(paragraph, size);
         })
         .unwrap();
@@ -123,7 +123,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
             let text = vec![Spans::from(s)];
             let paragraph = Paragraph::new(text)
                 .block(Block::default().borders(Borders::ALL))
-                .wrap(Wrap { trim: true });
+                .wrap(Wrap::default());
             f.render_widget(paragraph, size);
         })
         .unwrap();


### PR DESCRIPTION
Add optional callback to `Wrap` to compute the scroll offsets given the wrapped lines. This let
users compute the offsets dynamically.