### PR TITLE
feat: added type Block in canvas markers

### DIFF
--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -224,8 +224,10 @@ pub mod braille {
 /// Marker to use when plotting data points
 #[derive(Debug, Clone, Copy)]
 pub enum Marker {
-    /// One point per cell
+    /// One point per cell in shape of dot
     Dot,
+    /// One point per cell in shape of a block
+    Block,
     /// Up to 8 points per cell
     Braille,
 }

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -111,26 +111,28 @@ impl Grid for BrailleGrid {
 }
 
 #[derive(Debug, Clone)]
-struct DotGrid {
+struct SingleCellGrid {
     width: u16,
     height: u16,
     cells: Vec<char>,
     colors: Vec<Color>,
+    cell_char: char,
 }
 
-impl DotGrid {
-    fn new(width: u16, height: u16) -> DotGrid {
+impl SingleCellGrid {
+    fn new(width: u16, height: u16, cell_char: char) -> SingleCellGrid {
         let length = usize::from(width * height);
-        DotGrid {
+        SingleCellGrid {
             width,
             height,
             cells: vec![' '; length],
             colors: vec![Color::Reset; length],
+            cell_char,
         }
     }
 }
 
-impl Grid for DotGrid {
+impl Grid for SingleCellGrid {
     fn width(&self) -> u16 {
         self.width
     }
@@ -162,7 +164,7 @@ impl Grid for DotGrid {
     fn paint(&mut self, x: usize, y: usize, color: Color) {
         let index = y * self.width as usize + x;
         if let Some(c) = self.cells.get_mut(index) {
-            *c = '•';
+            *c = self.cell_char;
         }
         if let Some(c) = self.colors.get_mut(index) {
             *c = color;
@@ -259,7 +261,8 @@ impl<'a> Context<'a> {
         marker: symbols::Marker,
     ) -> Context<'a> {
         let grid: Box<dyn Grid> = match marker {
-            symbols::Marker::Dot => Box::new(DotGrid::new(width, height)),
+            symbols::Marker::Dot => Box::new(SingleCellGrid::new(width, height, '•')),
+            symbols::Marker::Block => Box::new(SingleCellGrid::new(width, height, '▄')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
         };
         Context {
@@ -396,8 +399,8 @@ where
     }
 
     /// Change the type of points used to draw the shapes. By default the braille patterns are used
-    /// as they provide a more fine grained result but you might want to use the simple dot instead
-    /// if the targeted terminal does not support those symbols.
+    /// as they provide a more fine grained result but you might want to use the simple dot or
+    /// block instead if the targeted terminal does not support those symbols.
     ///
     /// # Examples
     ///
@@ -407,6 +410,8 @@ where
     /// Canvas::default().marker(symbols::Marker::Braille).paint(|ctx| {});
     ///
     /// Canvas::default().marker(symbols::Marker::Dot).paint(|ctx| {});
+    ///
+    /// Canvas::default().marker(symbols::Marker::Block).paint(|ctx| {});
     /// ```
     pub fn marker(mut self, marker: symbols::Marker) -> Canvas<'a, F> {
         self.marker = marker;

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -111,7 +111,7 @@ impl Grid for BrailleGrid {
 }
 
 #[derive(Debug, Clone)]
-struct SingleCellGrid {
+struct CharGrid {
     width: u16,
     height: u16,
     cells: Vec<char>,
@@ -119,10 +119,10 @@ struct SingleCellGrid {
     cell_char: char,
 }
 
-impl SingleCellGrid {
-    fn new(width: u16, height: u16, cell_char: char) -> SingleCellGrid {
+impl CharGrid {
+    fn new(width: u16, height: u16, cell_char: char) -> CharGrid {
         let length = usize::from(width * height);
-        SingleCellGrid {
+        CharGrid {
             width,
             height,
             cells: vec![' '; length],
@@ -132,7 +132,7 @@ impl SingleCellGrid {
     }
 }
 
-impl Grid for SingleCellGrid {
+impl Grid for CharGrid {
     fn width(&self) -> u16 {
         self.width
     }
@@ -261,8 +261,8 @@ impl<'a> Context<'a> {
         marker: symbols::Marker,
     ) -> Context<'a> {
         let grid: Box<dyn Grid> = match marker {
-            symbols::Marker::Dot => Box::new(SingleCellGrid::new(width, height, '•')),
-            symbols::Marker::Block => Box::new(SingleCellGrid::new(width, height, '▄')),
+            symbols::Marker::Dot => Box::new(CharGrid::new(width, height, '•')),
+            symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
         };
         Context {


### PR DESCRIPTION
this allows for clearer colors than using Dot, especially when
decreasing the size of the terminal font in order to increase the
resolution of the canvas

the reason I think this can be useful, is here:

Before:
![image](https://user-images.githubusercontent.com/26300843/89501081-561e3100-d7f5-11ea-8cb7-e0d0a67c7013.png)

After:
![image](https://user-images.githubusercontent.com/26300843/89500966-24a56580-d7f5-11ea-972b-e2983d52aa25.png)

These two images have the same resolution (font is the smallest in my terminal) but blocks will show more color than dots

I'm not sure why, but I'm trying to port my emulator UI to TUI, which is very cool