### PR TITLE
refresh current view

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -311,4 +311,8 @@ where
     pub fn size(&self) -> io::Result<Rect> {
         self.backend.size()
     }
+
+    pub fn refresh(&mut self) -> io::Result<()> {
+        self.resize(self.size()?)
+    }
 }


### PR DESCRIPTION
Seems this is no way to refresh current view. If there is another good way to do this, please correct me.

The case is, if there are some additional stdout output, the view will become very strange, like this:

![issue](https://user-images.githubusercontent.com/3286111/90532636-10c11280-e1aa-11ea-88bf-25bcc2a577c1.png)

Can try with this demo file:

https://github.com/uuhan/tui-rs/blob/9337ad047a45a65f6320efc419178b71205de12e/examples/termion_demo.rs#L56
