### PR TITLE
Extend `Text` to be stylable and extendable

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -31,7 +31,7 @@ impl Viewport {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-/// Options to pass to [`Terminal::draw_with_options`]
+/// Options to pass to [`Terminal::with_options`]
 pub struct TerminalOptions {
     /// Viewport used to draw to the terminal
     pub viewport: Viewport,


### PR DESCRIPTION
This PR:

- Makes the `Text` constructors consistent with `Span` (adds `raw` and `styled`)
- Adds a `From<String>` implementation for `Text`
- Adds an `IntoIterator` implementation for `Text` (this is mainly for the `Extend` implementation, but it also means one can use `for` loops to iterate over the `Spans` of a `Text` object.
- Adds an `Extend` implementation for `Text`

This addresses #339 in a more thoughtful way than my last PR. To borrow a doctest from `Text` and show off the extension:

```rust
use tui::text::Text;
let mut text = Text::from("The first line\nThe second line");
assert_eq!(2, text.height());
text.extend(Text::raw("These are two\nmore lines!");
assert_eq!(4, text.height());
```  

There is obviously no documentation in this PR, as I don't know if this is an acceptable approach, but I'm happy to write that up if this is okay.

In the meantime, I'll be using these new extensions to re-implement some of my projects to test the ergonomics of this abstraction.