### PR TITLE
Add termchat to "apps using tui"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ You can run all examples by running `make run-examples`.
 * [desed](https://github.com/SoptikHa2/desed)
 * [diskonaut](https://github.com/imsnif/diskonaut)
 * [tickrs](https://github.com/tarkah/tickrs)
+* [termchat](https://github.com/lemunozm/termchat)
 
 ### Alternatives
 


### PR DESCRIPTION
Hi! 

I made [termchat](https://github.com/lemunozm/termchat) using `tui-rs`. I added it to the "apps using tui" list, but feel free to consider if it should be there because it seems simpler than the rest of the applications of the list.

Thank you for your effort in building `tui`!