### PR TITLE
Fix barchart incorrectly showing chart filled more than actual

### DIFF
--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -157,7 +157,7 @@ impl<'a> Widget for BarChart<'a> {
             .map(|&(l, v)| {
                 (
                     l,
-                    v * u64::from(chart_area.height) * 8 / std::cmp::max(max, 1),
+                    v * u64::from(chart_area.height - 1) * 8 / std::cmp::max(max, 1),
                 )
             })
             .collect::<Vec<(&str, u64)>>();

--- a/tests/widgets_barchart.rs
+++ b/tests/widgets_barchart.rs
@@ -1,0 +1,40 @@
+use tui::backend::TestBackend;
+use tui::buffer::Buffer;
+use tui::widgets::{BarChart, Block, Borders};
+use tui::Terminal;
+
+#[test]
+fn widgets_barchart_not_full_below_max_value() {
+    let test_case = |expected| {
+        let backend = TestBackend::new(30, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|f| {
+                let size = f.size();
+                let barchart = BarChart::default()
+                    .block(Block::default().borders(Borders::ALL))
+                    .data(&[("empty", 0), ("half", 50), ("almost", 99), ("full", 100)])
+                    .max(100)
+                    .bar_width(7)
+                    .bar_gap(0);
+                f.render_widget(barchart, size);
+            })
+            .unwrap();
+        terminal.backend().assert_buffer(&expected);
+    };
+
+    // check that bars fill up correctly up to max value
+    test_case(Buffer::with_lines(vec![
+        "┌────────────────────────────┐",
+        "│              ▇▇▇▇▇▇▇███████│",
+        "│              ██████████████│",
+        "│              ██████████████│",
+        "│       ▄▄▄▄▄▄▄██████████████│",
+        "│       █████████████████████│",
+        "│       █████████████████████│",
+        "│       ██50█████99█████100██│",
+        "│empty  half   almost full   │",
+        "└────────────────────────────┘",
+    ]));
+}


### PR DESCRIPTION
Determination of how filled the bar should be was incorrectly taking the
entire chart height into account, when in fact it should take height-1, because
of extra line with label. Because of that the chart appeared fuller than it
should and was full before reaching maximum value.