### PR TITLE
Fix percentage and ratio constraints for table to take borders into account

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -249,7 +249,9 @@ where
                     variables[i] | EQ(WEAK) | (f64::from(v * table_area.width) / 100.0)
                 }
                 Constraint::Ratio(n, d) => {
-                    variables[i] | EQ(WEAK) | (f64::from(table_area.width) * f64::from(n) / f64::from(d))
+                    variables[i]
+                        | EQ(WEAK)
+                        | (f64::from(table_area.width) * f64::from(n) / f64::from(d))
                 }
                 Constraint::Min(v) => variables[i] | GE(WEAK) | f64::from(v),
                 Constraint::Max(v) => variables[i] | LE(WEAK) | f64::from(v),

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -246,10 +246,10 @@ where
             ccs.push(match *constraint {
                 Constraint::Length(v) => variables[i] | EQ(MEDIUM) | f64::from(v),
                 Constraint::Percentage(v) => {
-                    variables[i] | EQ(WEAK) | (f64::from(v * area.width) / 100.0)
+                    variables[i] | EQ(WEAK) | (f64::from(v * table_area.width) / 100.0)
                 }
                 Constraint::Ratio(n, d) => {
-                    variables[i] | EQ(WEAK) | (f64::from(area.width) * f64::from(n) / f64::from(d))
+                    variables[i] | EQ(WEAK) | (f64::from(table_area.width) * f64::from(n) / f64::from(d))
                 }
                 Constraint::Min(v) => variables[i] | GE(WEAK) | f64::from(v),
                 Constraint::Max(v) => variables[i] | LE(WEAK) | f64::from(v),

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -273,7 +273,7 @@ where
             let value = if value.is_sign_negative() {
                 0
             } else {
-                value as u16
+                value.round() as u16
             };
             solved_widths[index] = value
         }

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -417,7 +417,6 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
     );
 }
 
-
 #[test]
 fn widgets_table_columns_widths_can_use_ratio_constraints() {
     let test_case = |widths, expected| {

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -248,9 +248,9 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
     // columns of not enough width trims the data
     test_case(
         &[
-            Constraint::Percentage(10),
-            Constraint::Percentage(10),
-            Constraint::Percentage(10),
+            Constraint::Percentage(11),
+            Constraint::Percentage(11),
+            Constraint::Percentage(11),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -269,9 +269,9 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
     // columns of large width just before pushing a column off
     test_case(
         &[
-            Constraint::Percentage(30),
-            Constraint::Percentage(30),
-            Constraint::Percentage(30),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -292,12 +292,12 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
         &[Constraint::Percentage(50), Constraint::Percentage(50)],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
-            "│Head1          Head2        │",
+            "│Head1         Head2         │",
             "│                            │",
-            "│Row11          Row12        │",
-            "│Row21          Row22        │",
-            "│Row31          Row32        │",
-            "│Row41          Row42        │",
+            "│Row11         Row12         │",
+            "│Row21         Row22         │",
+            "│Row31         Row32         │",
+            "│Row41         Row42         │",
             "│                            │",
             "│                            │",
             "└────────────────────────────┘",
@@ -356,9 +356,9 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
     // columns of not enough width trims the data
     test_case(
         &[
-            Constraint::Percentage(10),
+            Constraint::Percentage(11),
             Constraint::Length(20),
-            Constraint::Percentage(10),
+            Constraint::Percentage(11),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -377,9 +377,9 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
     // columns of large width just before pushing a column off
     test_case(
         &[
-            Constraint::Percentage(30),
+            Constraint::Percentage(33),
             Constraint::Length(10),
-            Constraint::Percentage(30),
+            Constraint::Percentage(33),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -410,6 +410,116 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
             "│Row21            Row22      │",
             "│Row31            Row32      │",
             "│Row41            Row42      │",
+            "│                            │",
+            "│                            │",
+            "└────────────────────────────┘",
+        ]),
+    );
+}
+
+
+#[test]
+fn widgets_table_columns_widths_can_use_ratio_constraints() {
+    let test_case = |widths, expected| {
+        let backend = TestBackend::new(30, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|f| {
+                let size = f.size();
+                let table = Table::new(
+                    ["Head1", "Head2", "Head3"].iter(),
+                    vec![
+                        Row::Data(["Row11", "Row12", "Row13"].iter()),
+                        Row::Data(["Row21", "Row22", "Row23"].iter()),
+                        Row::Data(["Row31", "Row32", "Row33"].iter()),
+                        Row::Data(["Row41", "Row42", "Row43"].iter()),
+                    ]
+                    .into_iter(),
+                )
+                .block(Block::default().borders(Borders::ALL))
+                .widths(widths)
+                .column_spacing(0);
+                f.render_widget(table, size);
+            })
+            .unwrap();
+        terminal.backend().assert_buffer(&expected);
+    };
+
+    // columns of zero width show nothing
+    test_case(
+        &[
+            Constraint::Ratio(0, 1),
+            Constraint::Ratio(0, 1),
+            Constraint::Ratio(0, 1),
+        ],
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│                            │",
+            "│                            │",
+            "│                            │",
+            "│                            │",
+            "│                            │",
+            "│                            │",
+            "│                            │",
+            "│                            │",
+            "└────────────────────────────┘",
+        ]),
+    );
+
+    // columns of not enough width trims the data
+    test_case(
+        &[
+            Constraint::Ratio(1, 9),
+            Constraint::Ratio(1, 9),
+            Constraint::Ratio(1, 9),
+        ],
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│HeaHeaHea                   │",
+            "│                            │",
+            "│RowRowRow                   │",
+            "│RowRowRow                   │",
+            "│RowRowRow                   │",
+            "│RowRowRow                   │",
+            "│                            │",
+            "│                            │",
+            "└────────────────────────────┘",
+        ]),
+    );
+
+    // columns of large width just before pushing a column off
+    test_case(
+        &[
+            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 3),
+        ],
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│Head1    Head2    Head3     │",
+            "│                            │",
+            "│Row11    Row12    Row13     │",
+            "│Row21    Row22    Row23     │",
+            "│Row31    Row32    Row33     │",
+            "│Row41    Row42    Row43     │",
+            "│                            │",
+            "│                            │",
+            "└────────────────────────────┘",
+        ]),
+    );
+
+    // percentages summing to 100 should give equal widths
+    test_case(
+        &[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)],
+        Buffer::with_lines(vec![
+            "┌────────────────────────────┐",
+            "│Head1         Head2         │",
+            "│                            │",
+            "│Row11         Row12         │",
+            "│Row21         Row22         │",
+            "│Row31         Row32         │",
+            "│Row41         Row42         │",
             "│                            │",
             "│                            │",
             "└────────────────────────────┘",


### PR DESCRIPTION
Percentage and ratio constraints don't take borders into account, which causes
the table to not be correctly aligned. This is easily seen when using 50/50
percentage split with bordered table. However fixing this causes the last column
of table to not get printed (see the failing test case), so there is probably another 
problem with columns width determination.
@fdehau could you take a look and see if you agree?