### PR TITLE
Upgrade crossterm to v0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
 rustbox = { version = "0.11", optional = true }
-crossterm = { version = "0.17", optional = true }
+crossterm = { version = "0.18", optional = true }
 easycurses = { version = "0.12.2", optional = true }
 pancurses = { version = "0.16.1", optional = true, features = ["win32a"] }
 serde = { version = "1", "optional" = true, features = ["derive"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! crossterm = "0.17"
+//! crossterm = "0.18"
 //! tui = { version = "0.12", default-features = false, features = ['crossterm'] }
 //! ```
 //!


### PR DESCRIPTION
Crossterm v0.18 reduces the amount of dependencies, among other improvements. I couldn't detect a breaking [change](https://github.com/crossterm-rs/crossterm/blob/master/CHANGELOG.md).