### PR TITLE
feat(widgets/listitem): derive PartialEq

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -36,7 +36,7 @@ impl ListState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ListItem<'a> {
     content: Text<'a>,
     style: Style,


### PR DESCRIPTION
While writing tests for my application I found it made things _a lot easier_ if I added `PartialEq` to `ListItem`. This way I can run assertions with an expected `Vec<ListItem>` against those that my app returns to verify everything is working correctly.
