### PR TITLE
Add offset method for ListState

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -24,6 +24,10 @@ impl Default for ListState {
 }
 
 impl ListState {
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
     pub fn selected(&self) -> Option<usize> {
         self.selected
     }


### PR DESCRIPTION
Add offset method for `ListState` so that things like interacting with mouse events would be easier.