### PR TITLE
Draw table header and border even if rows are empty

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -402,9 +402,6 @@ impl<'a> StatefulWidget for Table<'a> {
             return;
         }
         buf.set_style(area, self.style);
-        if self.rows.is_empty() {
-            return;
-        }
         let table_area = match self.block.take() {
             Some(b) => {
                 let inner_area = b.inner(area);
@@ -457,6 +454,9 @@ impl<'a> StatefulWidget for Table<'a> {
         }
 
         // Draw rows
+        if self.rows.is_empty() {
+            return;
+        }
         let (start, end) = self.get_row_bounds(state.selected, state.offset, rows_height);
         state.offset = start;
         for (i, table_row) in self

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -685,3 +685,33 @@ fn widgets_table_can_have_elements_styled_individually() {
     }
     terminal.backend().assert_buffer(&expected);
 }
+
+#[test]
+fn widgets_table_should_render_even_if_empty() {
+    let backend = TestBackend::new(30, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(vec![])
+                .header(Row::new(vec!["Head1", "Head2", "Head3"]))
+                .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
+                .widths(&[
+                    Constraint::Length(6),
+                    Constraint::Length(6),
+                    Constraint::Length(6),
+                ])
+                .column_spacing(1);
+            f.render_widget(table, size);
+        })
+        .unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "│Head1  Head2  Head3         │",
+        "│                            │",
+        "│                            │",
+        "│                            │",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}


### PR DESCRIPTION
If table rows are empty, it does not render at all.
I would expect header and empty border to be rendered.
