### PR TITLE
Add readme to Cargo.toml so that crates.io shows the README.md instead of an empty page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ description = """
 A library to build rich terminal user interfaces or dashboards
 """
 documentation = "https://docs.rs/tui/0.10.0/tui/"
+# crates.io will show the README.md of this repo instead of an empty page
+readme = "README.md"
 keywords = ["tui", "terminal", "dashboard"]
 repository = "https://github.com/fdehau/tui-rs"
 license = "MIT"


### PR DESCRIPTION
Hi. Cargo.toml is missing the "readme" field. This results in an empty page (one paragraph only) on crates.io https://crates.io/crates/tui

If you add this field/key the README.md will be visible on crates.io, like here: https://crates.io/crates/bat

This would attract more users if they immidately can see screenshots etc.

Happy holidays/merry christmas!