### PR TITLE
Update crossterm to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
 rustbox = { version = "0.11", optional = true }
-crossterm = { version = "0.18", optional = true }
+crossterm = { version = "0.19", optional = true }
 easycurses = { version = "0.12.2", optional = true }
 pancurses = { version = "0.16.1", optional = true, features = ["win32a"] }
 serde = { version = "1", "optional" = true, features = ["derive"]}

--- a/examples/crossterm_demo.rs
+++ b/examples/crossterm_demo.rs
@@ -12,7 +12,7 @@ use crossterm::{
 };
 use std::{
     error::Error,
-    io::{stdout, Write},
+    io::stdout,
     sync::mpsc,
     thread,
     time::{Duration, Instant},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! crossterm = "0.18"
+//! crossterm = "0.19"
 //! tui = { version = "0.14", default-features = false, features = ['crossterm'] }
 //! ```
 //!


### PR DESCRIPTION
Related [CHANGELOG](https://github.com/crossterm-rs/crossterm/blob/master/CHANGELOG.md#version-019) entries for 0.19.