### PR TITLE
Add Vector to list of projects using tui-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You can run all examples by running `make run-examples`.
 * [termchat](https://github.com/lemunozm/termchat)
 * [taskwarrior-tui](https://github.com/kdheepak/taskwarrior-tui)
 * [gping](https://github.com/orf/gping/)
+* [Vector](https://vector.dev)
 
 ### Alternatives
 


### PR DESCRIPTION
We use `tui-rs` for our [`vector top`](https://vector.dev/docs/reference/cli/#top) feature