### PR TITLE
Fix out of bounds table offset panic

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -334,7 +334,7 @@ impl<'a> Table<'a> {
         offset: usize,
         max_height: u16,
     ) -> (usize, usize) {
-        let offset = offset.min(self.rows.len() - 1);
+        let offset = offset.min(self.rows.len().saturating_sub(1));
         let mut start = offset;
         let mut end = offset;
         let mut height = 0;

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -334,6 +334,7 @@ impl<'a> Table<'a> {
         offset: usize,
         max_height: u16,
     ) -> (usize, usize) {
+        let offset = offset.min(self.rows.len() - 1);
         let mut start = offset;
         let mut end = offset;
         let mut height = 0;


### PR DESCRIPTION
So I have a TUI project I'm working on where I've supplied a method to filter out data from the Table widget, using a regex match. Whenever I do this I want to preserve the previous table state, so that the table can still scroll up or down relative to its previous position. For example, if just 1 entry were removed it would be preferable to preserve the offset instead of reset it to 0 and scroll down to the currently selected element. The issue this led to was an out-of-bounds index whenever the offset was greater than the length of the new data. The fix takes only 1 line: clamp the offset to the last index in the new list.