### PR TITLE
Actually clear buffer in TestBackend::clear

### DIFF
--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -137,6 +137,7 @@ impl Backend for TestBackend {
     }
 
     fn clear(&mut self) -> Result<(), io::Error> {
+        self.buffer.reset();
         Ok(())
     }
 


### PR DESCRIPTION
The `TestBackend::clear` function didn't actually do anything before.  This feature changes it to clear the buffer.

I ran into this because I'm testing my full application (instead of just specific widgets), and switching between screens (which have `terminal.clear()` calls in between) was leaving junk on the screen.