### PR TITLE
Added feature to align title of the block

### DIFF
--- a/examples/block.rs
+++ b/examples/block.rs
@@ -35,6 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let block = Block::default()
                 .borders(Borders::ALL)
                 .title("Main block with round corners")
+                .title_alignment(Alignment::Center)
                 .border_type(BorderType::Rounded);
             f.render_widget(block, size);
 

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout, Alignment},
+    layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, BorderType, Borders},
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
                 .split(chunks[0]);
-            
+
             // Top left inner block with green background
             let block = Block::default()
                 .title(vec![
@@ -60,14 +60,16 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .style(Style::default().bg(Color::Green));
             f.render_widget(block, top_chunks[0]);
 
-            // Top right inner block with styled title aligned to the right 
-            let block = Block::default().title(Span::styled(
-                "Styled title",
-                Style::default()
-                    .fg(Color::White)
-                    .bg(Color::Red)
-                    .add_modifier(Modifier::BOLD),
-            )).title_alignment(Alignment::Right);
+            // Top right inner block with styled title aligned to the right
+            let block = Block::default()
+                .title(Span::styled(
+                    "Styled title",
+                    Style::default()
+                        .fg(Color::White)
+                        .bg(Color::Red)
+                        .add_modifier(Modifier::BOLD),
+                ))
+                .title_alignment(Alignment::Right);
             f.render_widget(block, top_chunks[1]);
 
             // Bottom two inner blocks

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Alignment},
     style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, BorderType, Borders},
@@ -30,21 +30,27 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Just draw the block and the group on the same area and build the group
             // with at least a margin of 1
             let size = f.size();
+
+            // Surounding block
             let block = Block::default()
                 .borders(Borders::ALL)
                 .title("Main block with round corners")
                 .border_type(BorderType::Rounded);
             f.render_widget(block, size);
+
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(4)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
                 .split(f.size());
 
+            // Top two inner blocks
             let top_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
                 .split(chunks[0]);
+            
+            // Top left inner block with green background
             let block = Block::default()
                 .title(vec![
                     Span::styled("With", Style::default().fg(Color::Yellow)),
@@ -53,21 +59,27 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .style(Style::default().bg(Color::Green));
             f.render_widget(block, top_chunks[0]);
 
+            // Top right inner block with styled title aligned to the right 
             let block = Block::default().title(Span::styled(
                 "Styled title",
                 Style::default()
                     .fg(Color::White)
                     .bg(Color::Red)
                     .add_modifier(Modifier::BOLD),
-            ));
+            )).title_alignment(Alignment::Right);
             f.render_widget(block, top_chunks[1]);
 
+            // Bottom two inner blocks
             let bottom_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
                 .split(chunks[1]);
+
+            // Bottom left block with all default borders
             let block = Block::default().title("With borders").borders(Borders::ALL);
             f.render_widget(block, bottom_chunks[0]);
+
+            // Bottom right block with styled left and right border
             let block = Block::default()
                 .title("With styled borders and doubled borders")
                 .border_style(Style::default().fg(Color::Cyan))

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::Buffer,
-    layout::{Rect, Alignment},
+    layout::{Alignment, Rect},
     style::Style,
     symbols::line,
     text::{Span, Spans},
@@ -203,7 +203,6 @@ impl<'a> Widget for Block<'a> {
 
         // Title
         if let Some(title) = self.title {
-
             let left_border_dx = if self.borders.intersects(Borders::LEFT) {
                 1
             } else {
@@ -216,18 +215,20 @@ impl<'a> Widget for Block<'a> {
                 0
             };
 
-            let title_area_width = area.width.saturating_sub(left_border_dx)
-                                             .saturating_sub(right_border_dx);
+            let title_area_width = area
+                .width
+                .saturating_sub(left_border_dx)
+                .saturating_sub(right_border_dx);
 
             let title_dx = match self.title_alignment {
-                Alignment::Left   => 0,
+                Alignment::Left => 0,
                 Alignment::Center => (title_area_width - title.width() as u16) / 2,
-                Alignment::Right  => (title_area_width - title.width() as u16)
+                Alignment::Right => (title_area_width - title.width() as u16),
             };
 
             let title_x = area.left() + left_border_dx + title_dx;
             let title_y = area.top();
-            
+
             buf.set_spans(title_x, title_y, &title, title_area_width);
         }
     }
@@ -533,14 +534,14 @@ mod tests {
         );
         assert_eq!(
             Block::default()
-                  .title("Test")
-                  .title_alignment(Alignment::Center)
-                  .inner(Rect {
-                x: 0,
-                y: 0,
-                width: 0,
-                height: 1,
-            }),
+                .title("Test")
+                .title_alignment(Alignment::Center)
+                .inner(Rect {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 1,
+                }),
             Rect {
                 x: 0,
                 y: 1,
@@ -550,14 +551,14 @@ mod tests {
         );
         assert_eq!(
             Block::default()
-                  .title("Test")
-                  .title_alignment(Alignment::Right)
-                  .inner(Rect {
-                x: 0,
-                y: 0,
-                width: 0,
-                height: 1,
-            }),
+                .title("Test")
+                .title_alignment(Alignment::Right)
+                .inner(Rect {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 1,
+                }),
             Rect {
                 x: 0,
                 y: 1,

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -531,5 +531,39 @@ mod tests {
                 height: 0,
             },
         );
+        assert_eq!(
+            Block::default()
+                  .title("Test")
+                  .title_alignment(Alignment::Center)
+                  .inner(Rect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 1,
+            }),
+            Rect {
+                x: 0,
+                y: 1,
+                width: 0,
+                height: 0,
+            },
+        );
+        assert_eq!(
+            Block::default()
+                  .title("Test")
+                  .title_alignment(Alignment::Right)
+                  .inner(Rect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 1,
+            }),
+            Rect {
+                x: 0,
+                y: 1,
+                width: 0,
+                height: 0,
+            },
+        );
     }
 }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -221,12 +221,15 @@ impl<'a> Widget for Block<'a> {
                 .saturating_sub(right_border_dx);
 
             let title_dx = match self.title_alignment {
-                Alignment::Left => 0,
-                Alignment::Center => (title_area_width - title.width() as u16) / 2,
-                Alignment::Right => (title_area_width - title.width() as u16),
+                Alignment::Left => left_border_dx,
+                Alignment::Center => area.width.saturating_sub(title.width() as u16) / 2,
+                Alignment::Right => area
+                    .width
+                    .saturating_sub(title.width() as u16)
+                    .saturating_sub(right_border_dx),
             };
 
-            let title_x = area.left() + left_border_dx + title_dx;
+            let title_x = area.left() + title_dx;
             let title_y = area.top();
 
             buf.set_spans(title_x, title_y, &title, title_area_width);

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Rect, Alignment},
     style::Style,
     symbols::line,
     text::{Span, Spans},
@@ -45,6 +45,9 @@ impl BorderType {
 pub struct Block<'a> {
     /// Optional title place on the upper left of the block
     title: Option<Spans<'a>>,
+    /// Title alignment. The default is top left of the block, but one can choose to place
+    /// title in the top middle, or top right of the block
+    title_alignment: Alignment,
     /// Visible borders
     borders: Borders,
     /// Border style
@@ -60,6 +63,7 @@ impl<'a> Default for Block<'a> {
     fn default() -> Block<'a> {
         Block {
             title: None,
+            title_alignment: Alignment::Left,
             borders: Borders::NONE,
             border_style: Default::default(),
             border_type: BorderType::Plain,
@@ -86,6 +90,11 @@ impl<'a> Block<'a> {
             let title = String::from(t);
             self.title = Some(Spans::from(Span::styled(title, style)));
         }
+        self
+    }
+
+    pub fn title_alignment(mut self, alignment: Alignment) -> Block<'a> {
+        self.title_alignment = alignment;
         self
     }
 
@@ -192,19 +201,34 @@ impl<'a> Widget for Block<'a> {
                 .set_style(self.border_style);
         }
 
+        // Title
         if let Some(title) = self.title {
-            let lx = if self.borders.intersects(Borders::LEFT) {
+
+            let left_border_dx = if self.borders.intersects(Borders::LEFT) {
                 1
             } else {
                 0
             };
-            let rx = if self.borders.intersects(Borders::RIGHT) {
+
+            let right_border_dx = if self.borders.intersects(Borders::RIGHT) {
                 1
             } else {
                 0
             };
-            let width = area.width.saturating_sub(lx).saturating_sub(rx);
-            buf.set_spans(area.left() + lx, area.top(), &title, width);
+
+            let title_area_width = area.width.saturating_sub(left_border_dx)
+                                             .saturating_sub(right_border_dx);
+
+            let title_dx = match self.title_alignment {
+                Alignment::Left   => 0,
+                Alignment::Center => (title_area_width - title.width() as u16) / 2,
+                Alignment::Right  => (title_area_width - title.width() as u16)
+            };
+
+            let title_x = area.left() + left_border_dx + title_dx;
+            let title_y = area.top();
+            
+            buf.set_spans(title_x, title_y, &title, title_area_width);
         }
     }
 }

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -213,469 +213,134 @@ fn widgets_block_renders_on_small_areas() {
 }
 
 #[test]
-fn widgets_block_renders_title_top_left_all_borders() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
+fn widgets_block_title_alignment() {
+    let test_case = |alignment, borders, expected| {
+        let backend = TestBackend::new(15, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
 
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Left)
-        .borders(Borders::ALL);
+        let block = Block::default()
+            .title(Span::styled("Title", Style::default()))
+            .title_alignment(alignment)
+            .borders(borders);
 
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
+        let area = Rect {
+            x: 1,
+            y: 0,
+            width: 13,
+            height: 2,
+        };
+
+        terminal
+            .draw(|f| {
+                f.render_widget(block, area);
+            })
+            .unwrap();
+
+        terminal.backend().assert_buffer(&expected);
     };
 
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ┌Title───────────┐ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " └────────────────┘ ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_left_no_left_border() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Left)
-        .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " Title────────────┐ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        " ─────────────────┘ ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_left_no_right_border() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Left)
-        .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ┌Title──────────── ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " └───────────────── ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_left_no_borders() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Left)
-        .borders(Borders::NONE);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " Title              ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_center_all_borders() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Center)
-        .borders(Borders::ALL);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ┌─────Title──────┐ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " └────────────────┘ ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_center_no_left_border() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Center)
-        .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ──────Title──────┐ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        " ─────────────────┘ ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_center_no_right_border() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Center)
-        .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ┌──────Title────── ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " └───────────────── ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_center_no_borders() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Center)
-        .borders(Borders::NONE);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        "       Title        ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_right_all_borders() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Right)
-        .borders(Borders::ALL);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ┌───────────Title┐ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " │                │ ",
-        " └────────────────┘ ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_right_no_left_border() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Right)
-        .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ────────────Title┐ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        "                  │ ",
-        " ─────────────────┘ ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_right_no_right_border() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Right)
-        .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        " ┌────────────Title ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " │                  ",
-        " └───────────────── ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
-}
-
-#[test]
-fn widgets_block_renders_title_top_right_no_borders() {
-    let backend = TestBackend::new(20, 10);
-    let mut terminal = Terminal::new(backend).unwrap();
-
-    let block = Block::default()
-        .title(Span::styled("Title", Style::default()))
-        .title_alignment(Alignment::Right)
-        .borders(Borders::NONE);
-
-    let area = Rect {
-        x: 1,
-        y: 1,
-        width: 18,
-        height: 8,
-    };
-
-    terminal
-        .draw(|f| {
-            f.render_widget(block, area);
-        })
-        .unwrap();
-
-    let expected = Buffer::with_lines(vec![
-        "                    ",
-        "              Title ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-    ]);
-
-    terminal.backend().assert_buffer(&expected);
+    // title top-left with all borders
+    test_case(
+        Alignment::Left,
+        Borders::ALL,
+        Buffer::with_lines(vec![" ┌Title──────┐ ", " └───────────┘ "]),
+    );
+
+    // title top-left without top border
+    test_case(
+        Alignment::Left,
+        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
+        Buffer::with_lines(vec![" │Title      │ ", " └───────────┘ "]),
+    );
+
+    // title top-left with no left border
+    test_case(
+        Alignment::Left,
+        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
+        Buffer::with_lines(vec![" Title───────┐ ", " ────────────┘ "]),
+    );
+
+    // title top-left without right border
+    test_case(
+        Alignment::Left,
+        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ┌Title─────── ", " └──────────── "]),
+    );
+
+    // title top-left without borders
+    test_case(
+        Alignment::Left,
+        Borders::NONE,
+        Buffer::with_lines(vec![" Title         ", "               "]),
+    );
+
+    // title center with all borders
+    test_case(
+        Alignment::Center,
+        Borders::ALL,
+        Buffer::with_lines(vec![" ┌───Title───┐ ", " └───────────┘ "]),
+    );
+
+    // title center without top border
+    test_case(
+        Alignment::Center,
+        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
+        Buffer::with_lines(vec![" │   Title   │ ", " └───────────┘ "]),
+    );
+
+    // title center with no left border
+    test_case(
+        Alignment::Center,
+        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ────Title───┐ ", " ────────────┘ "]),
+    );
+
+    // title center without right border
+    test_case(
+        Alignment::Center,
+        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ┌───Title──── ", " └──────────── "]),
+    );
+
+    // title center without borders
+    test_case(
+        Alignment::Center,
+        Borders::NONE,
+        Buffer::with_lines(vec!["     Title     ", "               "]),
+    );
+
+    // title top-right with all borders
+    test_case(
+        Alignment::Right,
+        Borders::ALL,
+        Buffer::with_lines(vec![" ┌──────Title┐ ", " └───────────┘ "]),
+    );
+
+    // title top-right without top border
+    test_case(
+        Alignment::Right,
+        Borders::LEFT | Borders::BOTTOM | Borders::RIGHT,
+        Buffer::with_lines(vec![" │      Title│ ", " └───────────┘ "]),
+    );
+
+    // title top-right with no left border
+    test_case(
+        Alignment::Right,
+        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ───────Title┐ ", " ────────────┘ "]),
+    );
+
+    // title top-right without right border
+    test_case(
+        Alignment::Right,
+        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ┌───────Title ", " └──────────── "]),
+    );
+
+    // title top-right without borders
+    test_case(
+        Alignment::Right,
+        Borders::NONE,
+        Buffer::with_lines(vec!["         Title ", "               "]),
+    );
 }

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -1,7 +1,7 @@
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
-    layout::{Rect, Alignment},
+    layout::{Alignment, Rect},
     style::{Color, Style},
     text::Span,
     widgets::{Block, Borders},
@@ -218,9 +218,9 @@ fn widgets_block_renders_title_top_left_all_borders() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Left)
-                .borders(Borders::ALL);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Left)
+        .borders(Borders::ALL);
 
     let area = Rect {
         x: 1,
@@ -229,7 +229,11 @@ fn widgets_block_renders_title_top_left_all_borders() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -253,9 +257,9 @@ fn widgets_block_renders_title_top_left_no_left_border() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Left)
-                .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Left)
+        .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
 
     let area = Rect {
         x: 1,
@@ -264,7 +268,11 @@ fn widgets_block_renders_title_top_left_no_left_border() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -288,9 +296,9 @@ fn widgets_block_renders_title_top_left_no_right_border() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Left)
-                .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Left)
+        .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
 
     let area = Rect {
         x: 1,
@@ -299,7 +307,11 @@ fn widgets_block_renders_title_top_left_no_right_border() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -323,9 +335,9 @@ fn widgets_block_renders_title_top_left_no_borders() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Left)
-                .borders(Borders::NONE);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Left)
+        .borders(Borders::NONE);
 
     let area = Rect {
         x: 1,
@@ -334,7 +346,11 @@ fn widgets_block_renders_title_top_left_no_borders() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -358,9 +374,9 @@ fn widgets_block_renders_title_top_center_all_borders() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Center)
-                .borders(Borders::ALL);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL);
 
     let area = Rect {
         x: 1,
@@ -369,7 +385,11 @@ fn widgets_block_renders_title_top_center_all_borders() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -393,9 +413,9 @@ fn widgets_block_renders_title_top_center_no_left_border() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Center)
-                .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
 
     let area = Rect {
         x: 1,
@@ -404,7 +424,11 @@ fn widgets_block_renders_title_top_center_no_left_border() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -428,9 +452,9 @@ fn widgets_block_renders_title_top_center_no_right_border() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Center)
-                .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
 
     let area = Rect {
         x: 1,
@@ -439,7 +463,11 @@ fn widgets_block_renders_title_top_center_no_right_border() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -463,9 +491,9 @@ fn widgets_block_renders_title_top_center_no_borders() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Center)
-                .borders(Borders::NONE);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::NONE);
 
     let area = Rect {
         x: 1,
@@ -474,7 +502,11 @@ fn widgets_block_renders_title_top_center_no_borders() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -498,9 +530,9 @@ fn widgets_block_renders_title_top_right_all_borders() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Right)
-                .borders(Borders::ALL);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Right)
+        .borders(Borders::ALL);
 
     let area = Rect {
         x: 1,
@@ -509,7 +541,11 @@ fn widgets_block_renders_title_top_right_all_borders() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -533,9 +569,9 @@ fn widgets_block_renders_title_top_right_no_left_border() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Right)
-                .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Right)
+        .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
 
     let area = Rect {
         x: 1,
@@ -544,7 +580,11 @@ fn widgets_block_renders_title_top_right_no_left_border() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -568,9 +608,9 @@ fn widgets_block_renders_title_top_right_no_right_border() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Right)
-                .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Right)
+        .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
 
     let area = Rect {
         x: 1,
@@ -579,7 +619,11 @@ fn widgets_block_renders_title_top_right_no_right_border() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",
@@ -603,9 +647,9 @@ fn widgets_block_renders_title_top_right_no_borders() {
     let mut terminal = Terminal::new(backend).unwrap();
 
     let block = Block::default()
-                .title(Span::styled("Title", Style::default()))
-                .title_alignment(Alignment::Right)
-                .borders(Borders::NONE);
+        .title(Span::styled("Title", Style::default()))
+        .title_alignment(Alignment::Right)
+        .borders(Borders::NONE);
 
     let area = Rect {
         x: 1,
@@ -614,7 +658,11 @@ fn widgets_block_renders_title_top_right_no_borders() {
         height: 8,
     };
 
-    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+    terminal
+        .draw(|f| {
+            f.render_widget(block, area);
+        })
+        .unwrap();
 
     let expected = Buffer::with_lines(vec![
         "                    ",

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -1,7 +1,7 @@
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
-    layout::Rect,
+    layout::{Rect, Alignment},
     style::{Color, Style},
     text::Span,
     widgets::{Block, Borders},
@@ -210,4 +210,424 @@ fn widgets_block_renders_on_small_areas() {
         },
         Buffer::with_lines(vec!["┌Test─"]),
     );
+}
+
+#[test]
+fn widgets_block_renders_title_top_left_all_borders() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Left)
+                .borders(Borders::ALL);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ┌Title───────────┐ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " └────────────────┘ ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_left_no_left_border() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Left)
+                .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " Title────────────┐ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        " ─────────────────┘ ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_left_no_right_border() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Left)
+                .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ┌Title──────────── ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " └───────────────── ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_left_no_borders() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Left)
+                .borders(Borders::NONE);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " Title              ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_center_all_borders() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ┌─────Title──────┐ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " └────────────────┘ ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_center_no_left_border() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Center)
+                .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ──────Title──────┐ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        " ─────────────────┘ ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_center_no_right_border() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Center)
+                .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ┌──────Title────── ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " └───────────────── ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_center_no_borders() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Center)
+                .borders(Borders::NONE);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        "       Title        ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_right_all_borders() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Right)
+                .borders(Borders::ALL);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ┌───────────Title┐ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " │                │ ",
+        " └────────────────┘ ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_right_no_left_border() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Right)
+                .borders(Borders::TOP | Borders::RIGHT | Borders::BOTTOM);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ────────────Title┐ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        "                  │ ",
+        " ─────────────────┘ ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_right_no_right_border() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Right)
+                .borders(Borders::LEFT | Borders::TOP | Borders::BOTTOM);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        " ┌────────────Title ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " │                  ",
+        " └───────────────── ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_block_renders_title_top_right_no_borders() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let block = Block::default()
+                .title(Span::styled("Title", Style::default()))
+                .title_alignment(Alignment::Right)
+                .borders(Borders::NONE);
+
+    let area = Rect {
+        x: 1,
+        y: 1,
+        width: 18,
+        height: 8,
+    };
+
+    terminal.draw(|f| { f.render_widget(block, area); }).unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        "                    ",
+        "              Title ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+    ]);
+
+    terminal.backend().assert_buffer(&expected);
 }


### PR DESCRIPTION
This is PR for https://github.com/fdehau/tui-rs/issues/450

- Added title_alignment field to block struct
- Added title_alignment() method to set title_alignment of the block
- Added comments and title alignment to the example/block.rs
- Added tests for title alignment in tests/widgets_block.rs
- Added tests in srs/block.rs for inner

For all above, used layout::Alignment enum as the type for title_alignment.