### PR TITLE
Fix compile warning in test.rs

### DIFF
--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -101,7 +101,7 @@ impl TestBackend {
             .collect::<Vec<String>>()
             .join("\n");
         debug_info.push_str(&nice_diff);
-        panic!(debug_info);
+        panic!("{}", debug_info);
     }
 }
 


### PR DESCRIPTION
The occurrence of `panic!(debug_info)` was causing a compile warning, and will be a hard error in Rust 2021 edition.
This commit fixes the issue.