### PR TITLE
Give the crate::widgets::reflow module public visibility

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -23,7 +23,7 @@ mod clear;
 mod gauge;
 mod list;
 mod paragraph;
-mod reflow;
+pub mod reflow;
 mod sparkline;
 mod table;
 mod tabs;


### PR DESCRIPTION
I'm writing a new widget for `tui-rs` ecosystem that I eventually plan to open-source.
But the new widget needs access to either the `widgets::reflow` library, or copy the code.
Reuse seems like the better option to me.