### PR TITLE
api: refactor error handling, make draw method fallible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "1"
 
 [dev-dependencies]
 rand = "0.8"
+anyhow = "1"
 argh = "0.1"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ crossterm = { version = "0.19", optional = true }
 easycurses = { version = "0.12.2", optional = true }
 pancurses = { version = "0.16.1", optional = true, features = ["win32a"] }
 serde = { version = "1", "optional" = true, features = ["derive"]}
+thiserror = "1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -2,7 +2,7 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use std::{convert::Infallible, error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -114,6 +114,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .add_modifier(Modifier::ITALIC),
                 );
             f.render_widget(barchart, chunks[1]);
+            Ok::<_, Infallible>(())
         })?;
 
         match events.next()? {

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -2,7 +2,8 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -13,7 +14,7 @@ use tui::{
     Terminal,
 };
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -74,6 +75,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .borders(Borders::LEFT | Borders::RIGHT)
                 .border_type(BorderType::Double);
             f.render_widget(block, bottom_chunks[1]);
+            Ok::<_, Infallible>(())
         })?;
 
         if let Event::Input(key) = events.next()? {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -2,7 +2,8 @@
 mod util;
 
 use crate::util::event::{Config, Event, Events};
-use std::{error::Error, io, time::Duration};
+use anyhow::Result;
+use std::{convert::Infallible, io, time::Duration};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -72,7 +73,7 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -116,6 +117,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .x_bounds([10.0, 110.0])
                 .y_bounds([10.0, 110.0]);
             f.render_widget(canvas, chunks[1]);
+            Ok::<_, Infallible>(())
         })?;
 
         match events.next()? {

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -5,7 +5,8 @@ use crate::util::{
     event::{Event, Events},
     SinSignal,
 };
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -65,7 +66,7 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -228,6 +229,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         ]),
                 );
             f.render_widget(chart, chunks[2]);
+            Ok::<_, Infallible>(())
         })?;
 
         match events.next()? {

--- a/examples/crossterm_demo.rs
+++ b/examples/crossterm_demo.rs
@@ -11,6 +11,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use std::{
+    convert::Infallible,
     error::Error,
     io::stdout,
     sync::mpsc,
@@ -75,7 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.clear()?;
 
     loop {
-        terminal.draw(|f| ui::draw(f, &mut app))?;
+        terminal.draw(|f| Ok::<_, Infallible>(ui::draw(f, &mut app)))?;
         match rx.recv()? {
             Event::Input(event) => match event.code {
                 KeyCode::Char('q') => {

--- a/examples/curses_demo.rs
+++ b/examples/curses_demo.rs
@@ -5,6 +5,7 @@ mod util;
 use crate::demo::{ui, App};
 use argh::FromArgs;
 use std::{
+    convert::Infallible,
     error::Error,
     io,
     time::{Duration, Instant},
@@ -40,7 +41,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_tick = Instant::now();
     let tick_rate = Duration::from_millis(cli.tick_rate);
     loop {
-        terminal.draw(|f| ui::draw(f, &mut app))?;
+        terminal.draw(|f| Ok::<_, Infallible>(ui::draw(f, &mut app)))?;
         if let Some(input) = terminal.backend_mut().get_curses_mut().get_input() {
             match input {
                 easycurses::Input::Character(c) => {

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -2,7 +2,8 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend, buffer::Buffer, layout::Rect, style::Style, widgets::Widget, Terminal,
@@ -31,7 +32,7 @@ impl<'a> Label<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -46,6 +47,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let size = f.size();
             let label = Label::default().text("Test");
             f.render_widget(label, size);
+            Ok::<_, Infallible>(())
         })?;
 
         if let Event::Input(key) = events.next()? {

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -2,7 +2,8 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -49,7 +50,7 @@ impl App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -109,6 +110,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .label(label)
                 .use_unicode(true);
             f.render_widget(gauge, chunks[3]);
+            Ok::<_, Infallible>(())
         })?;
 
         match events.next()? {

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -2,7 +2,9 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::convert::Infallible;
+use std::io;
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -11,7 +13,7 @@ use tui::{
     Terminal,
 };
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -39,6 +41,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             f.render_widget(block, chunks[0]);
             let block = Block::default().title("Block 2").borders(Borders::ALL);
             f.render_widget(block, chunks[2]);
+            Ok::<_, Infallible>(())
         })?;
 
         if let Event::Input(input) = events.next()? {

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -5,7 +5,8 @@ use crate::util::{
     event::{Event, Events},
     StatefulList,
 };
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -96,7 +97,7 @@ impl<'a> App<'a> {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -191,6 +192,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .block(Block::default().borders(Borders::ALL).title("List"))
                 .start_corner(Corner::BottomLeft);
             f.render_widget(events_list, chunks[1]);
+            Ok::<_, Infallible>(())
         })?;
 
         // This is a simple example on how to handle events

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -2,7 +2,8 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -13,7 +14,7 @@ use tui::{
     Terminal,
 };
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -96,6 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .alignment(Alignment::Right)
                 .wrap(Wrap { trim: true });
             f.render_widget(paragraph, chunks[3]);
+            Ok::<_, Infallible>(())
         })?;
 
         scroll += 1;

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -2,7 +2,8 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -41,7 +42,7 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
         .split(popup_layout[1])[1]
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -93,6 +94,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let area = centered_rect(60, 20, size);
             f.render_widget(Clear, area); //this clears out the background
             f.render_widget(block, area);
+            Ok::<_, Infallible>(())
         })?;
 
         if let Event::Input(input) = events.next()? {

--- a/examples/rustbox_demo.rs
+++ b/examples/rustbox_demo.rs
@@ -6,6 +6,7 @@ use crate::demo::{ui, App};
 use argh::FromArgs;
 use rustbox::keyboard::Key;
 use std::{
+    convert::Infallible,
     error::Error,
     time::{Duration, Instant},
 };
@@ -33,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_tick = Instant::now();
     let tick_rate = Duration::from_millis(cli.tick_rate);
     loop {
-        terminal.draw(|f| ui::draw(f, &mut app))?;
+        terminal.draw(|f| Ok::<_, Infallible>(ui::draw(f, &mut app)))?;
         if let Ok(rustbox::Event::KeyEvent(key)) =
             terminal.backend().rustbox().peek_event(tick_rate, false)
         {

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -5,7 +5,8 @@ use crate::util::{
     event::{Event, Events},
     RandomSignal,
 };
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -106,6 +107,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .data(&app.data3)
                 .style(Style::default().fg(Color::Red));
             f.render_widget(sparkline, chunks[2]);
+            Ok::<_, Infallible>(())
         })?;
 
         match events.next()? {

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -2,7 +2,7 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use std::{convert::Infallible, error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -123,6 +123,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     Constraint::Max(10),
                 ]);
             f.render_stateful_widget(t, rects[0], &mut table.state);
+            Ok::<_, Infallible>(())
         })?;
 
         if let Event::Input(key) = events.next()? {

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -5,7 +5,7 @@ use crate::util::{
     event::{Event, Events},
     TabsState,
 };
-use std::{error::Error, io};
+use std::{convert::Infallible, error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -77,6 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 _ => unreachable!(),
             };
             f.render_widget(inner, chunks[1]);
+            Ok::<_, Infallible>(())
         })?;
 
         if let Event::Input(input) = events.next()? {

--- a/examples/termion_demo.rs
+++ b/examples/termion_demo.rs
@@ -6,8 +6,9 @@ use crate::{
     demo::{ui, App},
     util::event::{Config, Event, Events},
 };
+use anyhow::Result;
 use argh::FromArgs;
-use std::{error::Error, io, time::Duration};
+use std::{convert::Infallible, io, time::Duration};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{backend::TermionBackend, Terminal};
 
@@ -22,7 +23,7 @@ struct Cli {
     enhanced_graphics: bool,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     let cli: Cli = argh::from_env();
 
     let events = Events::with_config(Config {
@@ -38,7 +39,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut app = App::new("Termion demo", cli.enhanced_graphics);
     loop {
-        terminal.draw(|f| ui::draw(f, &mut app))?;
+        terminal.draw(|f| Ok::<_, Infallible>(ui::draw(f, &mut app)))?;
 
         match events.next()? {
             Event::Input(key) => match key {

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -14,7 +14,8 @@
 mod util;
 
 use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use anyhow::Result;
+use std::{convert::Infallible, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
@@ -51,7 +52,7 @@ impl Default for App {
     }
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Terminal initialization
     let stdout = io::stdout().into_raw_mode()?;
     let stdout = MouseTerminal::from(stdout);
@@ -143,6 +144,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let messages =
                 List::new(messages).block(Block::default().borders(Borders::ALL).title("Messages"));
             f.render_widget(messages, chunks[2]);
+            Ok::<_, Infallible>(())
         })?;
 
         // Handle input

--- a/src/backend/curses.rs
+++ b/src/backend/curses.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use crate::backend::Backend;
 use crate::buffer::Cell;
 use crate::layout::Rect;
@@ -7,8 +5,10 @@ use crate::style::{Color, Modifier};
 use crate::symbols::{bar, block};
 #[cfg(unix)]
 use crate::symbols::{line, DOT};
+use crate::Error;
 #[cfg(unix)]
 use pancurses::{chtype, ToChtype};
+use std::io;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub struct CursesBackend {
@@ -35,7 +35,7 @@ impl CursesBackend {
 }
 
 impl Backend for CursesBackend {
-    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {

--- a/src/backend/curses.rs
+++ b/src/backend/curses.rs
@@ -7,7 +7,7 @@ use crate::symbols::{bar, block};
 use crate::symbols::{line, DOT};
 #[cfg(unix)]
 use pancurses::{chtype, ToChtype};
-use std::convert::Infallible;
+pub use std::convert::Infallible as Error;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub struct CursesBackend {
@@ -34,7 +34,7 @@ impl CursesBackend {
 }
 
 impl Backend for CursesBackend {
-    type Error = Infallible;
+    type Error = Error;
 
     fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
     where

--- a/src/backend/curses.rs
+++ b/src/backend/curses.rs
@@ -5,10 +5,9 @@ use crate::style::{Color, Modifier};
 use crate::symbols::{bar, block};
 #[cfg(unix)]
 use crate::symbols::{line, DOT};
-use crate::Error;
 #[cfg(unix)]
 use pancurses::{chtype, ToChtype};
-use std::io;
+use std::convert::Infallible;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub struct CursesBackend {
@@ -35,7 +34,9 @@ impl CursesBackend {
 }
 
 impl Backend for CursesBackend {
-    fn draw<'a, I>(&mut self, content: I) -> Result<(), Error>
+    type Error = Infallible;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
@@ -93,34 +94,41 @@ impl Backend for CursesBackend {
         ));
         Ok(())
     }
-    fn hide_cursor(&mut self) -> io::Result<()> {
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
         self.curses
             .set_cursor_visibility(easycurses::CursorVisibility::Invisible);
         Ok(())
     }
-    fn show_cursor(&mut self) -> io::Result<()> {
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
         self.curses
             .set_cursor_visibility(easycurses::CursorVisibility::Visible);
         Ok(())
     }
-    fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
+
+    fn get_cursor(&mut self) -> Result<(u16, u16), Self::Error> {
         let (y, x) = self.curses.get_cursor_rc();
         Ok((x as u16, y as u16))
     }
-    fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
+
+    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Self::Error> {
         self.curses.move_rc(i32::from(y), i32::from(x));
         Ok(())
     }
-    fn clear(&mut self) -> io::Result<()> {
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
         self.curses.clear();
         // self.curses.refresh();
         Ok(())
     }
-    fn size(&self) -> Result<Rect, io::Error> {
+
+    fn size(&self) -> Result<Rect, Self::Error> {
         let (nrows, ncols) = self.curses.get_row_col_count();
         Ok(Rect::new(0, 0, ncols as u16, nrows as u16))
     }
-    fn flush(&mut self) -> io::Result<()> {
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
         self.curses.refresh();
         Ok(())
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,6 @@
-use std::io;
-
 use crate::buffer::Cell;
 use crate::layout::Rect;
+use crate::Error;
 
 #[cfg(feature = "rustbox")]
 mod rustbox;
@@ -27,14 +26,14 @@ mod test;
 pub use self::test::TestBackend;
 
 pub trait Backend {
-    fn draw<'a, I>(&mut self, content: I) -> Result<(), io::Error>
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>;
-    fn hide_cursor(&mut self) -> Result<(), io::Error>;
-    fn show_cursor(&mut self) -> Result<(), io::Error>;
-    fn get_cursor(&mut self) -> Result<(u16, u16), io::Error>;
-    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), io::Error>;
-    fn clear(&mut self) -> Result<(), io::Error>;
-    fn size(&self) -> Result<Rect, io::Error>;
-    fn flush(&mut self) -> Result<(), io::Error>;
+    fn hide_cursor(&mut self) -> Result<(), Error>;
+    fn show_cursor(&mut self) -> Result<(), Error>;
+    fn get_cursor(&mut self) -> Result<(u16, u16), Error>;
+    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Error>;
+    fn clear(&mut self) -> Result<(), Error>;
+    fn size(&self) -> Result<Rect, Error>;
+    fn flush(&mut self) -> Result<(), Error>;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,24 +1,23 @@
 use crate::buffer::Cell;
 use crate::layout::Rect;
-use crate::Error;
 
 #[cfg(feature = "rustbox")]
-mod rustbox;
+pub(super) mod rustbox;
 #[cfg(feature = "rustbox")]
 pub use self::rustbox::RustboxBackend;
 
 #[cfg(feature = "termion")]
-mod termion;
+pub(super) mod termion;
 #[cfg(feature = "termion")]
 pub use self::termion::TermionBackend;
 
 #[cfg(feature = "crossterm")]
-mod crossterm;
+pub(super) mod crossterm;
 #[cfg(feature = "crossterm")]
 pub use self::crossterm::CrosstermBackend;
 
 #[cfg(feature = "curses")]
-mod curses;
+pub(super) mod curses;
 #[cfg(feature = "curses")]
 pub use self::curses::CursesBackend;
 
@@ -26,14 +25,16 @@ mod test;
 pub use self::test::TestBackend;
 
 pub trait Backend {
-    fn draw<'a, I>(&mut self, content: I) -> Result<(), Error>
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>;
-    fn hide_cursor(&mut self) -> Result<(), Error>;
-    fn show_cursor(&mut self) -> Result<(), Error>;
-    fn get_cursor(&mut self) -> Result<(u16, u16), Error>;
-    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Error>;
-    fn clear(&mut self) -> Result<(), Error>;
-    fn size(&self) -> Result<Rect, Error>;
-    fn flush(&mut self) -> Result<(), Error>;
+    fn hide_cursor(&mut self) -> Result<(), Self::Error>;
+    fn show_cursor(&mut self) -> Result<(), Self::Error>;
+    fn get_cursor(&mut self) -> Result<(u16, u16), Self::Error>;
+    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Self::Error>;
+    fn clear(&mut self) -> Result<(), Self::Error>;
+    fn size(&self) -> Result<Rect, Self::Error>;
+    fn flush(&mut self) -> Result<(), Self::Error>;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,10 +4,14 @@ use crate::layout::Rect;
 #[cfg(feature = "rustbox")]
 pub(super) mod rustbox;
 #[cfg(feature = "rustbox")]
+pub use self::rustbox::Error as RustboxError;
+#[cfg(feature = "rustbox")]
 pub use self::rustbox::RustboxBackend;
 
 #[cfg(feature = "termion")]
 pub(super) mod termion;
+#[cfg(feature = "termion")]
+pub use self::termion::Error as TermionError;
 #[cfg(feature = "termion")]
 pub use self::termion::TermionBackend;
 
@@ -15,11 +19,15 @@ pub use self::termion::TermionBackend;
 pub(super) mod crossterm;
 #[cfg(feature = "crossterm")]
 pub use self::crossterm::CrosstermBackend;
+#[cfg(feature = "crossterm")]
+pub use self::crossterm::Error as CrosstermError;
 
 #[cfg(feature = "curses")]
 pub(super) mod curses;
 #[cfg(feature = "curses")]
 pub use self::curses::CursesBackend;
+#[cfg(feature = "curses")]
+pub use self::curses::Error as CursesError;
 
 mod test;
 pub use self::test::TestBackend;

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -2,8 +2,9 @@ use crate::{
     backend::Backend,
     buffer::{Buffer, Cell},
     layout::Rect,
+    Error,
 };
-use std::{fmt::Write, io};
+use std::fmt::Write;
 use unicode_width::UnicodeWidthStr;
 
 /// A backend used for the integration tests.
@@ -106,7 +107,7 @@ impl TestBackend {
 }
 
 impl Backend for TestBackend {
-    fn draw<'a, I>(&mut self, content: I) -> Result<(), io::Error>
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
@@ -117,21 +118,21 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn hide_cursor(&mut self) -> Result<(), io::Error> {
+    fn hide_cursor(&mut self) -> Result<(), Error> {
         self.cursor = false;
         Ok(())
     }
 
-    fn show_cursor(&mut self) -> Result<(), io::Error> {
+    fn show_cursor(&mut self) -> Result<(), Error> {
         self.cursor = true;
         Ok(())
     }
 
-    fn get_cursor(&mut self) -> Result<(u16, u16), io::Error> {
+    fn get_cursor(&mut self) -> Result<(u16, u16), Error> {
         Ok(self.pos)
     }
 
-    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), io::Error> {
+    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Error> {
         self.pos = (x, y);
         Ok(())
     }
@@ -141,11 +142,11 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn size(&self) -> Result<Rect, io::Error> {
+    fn size(&self) -> Result<Rect, Error> {
         Ok(Rect::new(0, 0, self.width, self.height))
     }
 
-    fn flush(&mut self) -> Result<(), io::Error> {
+    fn flush(&mut self) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -137,7 +137,7 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn clear(&mut self) -> Result<(), io::Error> {
+    fn clear(&mut self) -> Result<(), Error> {
         self.buffer.reset();
         Ok(())
     }

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -2,9 +2,8 @@ use crate::{
     backend::Backend,
     buffer::{Buffer, Cell},
     layout::Rect,
-    Error,
 };
-use std::fmt::Write;
+use std::{convert::Infallible, fmt::Write};
 use unicode_width::UnicodeWidthStr;
 
 /// A backend used for the integration tests.
@@ -47,8 +46,8 @@ fn buffer_view(buffer: &Buffer) -> String {
 }
 
 impl TestBackend {
-    pub fn new(width: u16, height: u16) -> TestBackend {
-        TestBackend {
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
             width,
             height,
             buffer: Buffer::empty(Rect::new(0, 0, width, height)),
@@ -107,7 +106,9 @@ impl TestBackend {
 }
 
 impl Backend for TestBackend {
-    fn draw<'a, I>(&mut self, content: I) -> Result<(), Error>
+    type Error = Infallible;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
@@ -118,35 +119,35 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn hide_cursor(&mut self) -> Result<(), Error> {
+    fn hide_cursor(&mut self) -> Result<(), Infallible> {
         self.cursor = false;
         Ok(())
     }
 
-    fn show_cursor(&mut self) -> Result<(), Error> {
+    fn show_cursor(&mut self) -> Result<(), Infallible> {
         self.cursor = true;
         Ok(())
     }
 
-    fn get_cursor(&mut self) -> Result<(u16, u16), Error> {
+    fn get_cursor(&mut self) -> Result<(u16, u16), Infallible> {
         Ok(self.pos)
     }
 
-    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Error> {
+    fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Infallible> {
         self.pos = (x, y);
         Ok(())
     }
 
-    fn clear(&mut self) -> Result<(), Error> {
+    fn clear(&mut self) -> Result<(), Infallible> {
         self.buffer.reset();
         Ok(())
     }
 
-    fn size(&self) -> Result<Rect, Error> {
+    fn size(&self) -> Result<Rect, Infallible> {
         Ok(Rect::new(0, 0, self.width, self.height))
     }
 
-    fn flush(&mut self) -> Result<(), Error> {
+    fn flush(&mut self) -> Result<(), Infallible> {
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,8 @@
 #[derive(Debug, thiserror::Error)]
-pub enum Error<B, D>
-where
-    B: std::error::Error + Sync + Sync + 'static,
-    D: std::error::Error + Sync + Sync + 'static,
-{
+pub enum Error {
     #[error("failed to execute backend operation")]
-    Backend(#[source] B),
+    Backend(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
     #[error("failed to draw frame")]
-    DrawFrame(#[source] D),
+    DrawFrame(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,10 @@
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum Error<B>
+where
+    B: std::error::Error + Send + Sync + 'static,
+{
     #[error("failed to execute backend operation")]
-    Backend(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    Backend(#[source] B),
 
     #[error("failed to draw frame")]
     DrawFrame(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
 #[derive(Debug, thiserror::Error)]
-pub enum Error<B>
+pub enum Error<B, D>
 where
     B: std::error::Error + Send + Sync + 'static,
+    D: std::error::Error + Send + Sync + 'static,
 {
     #[error("failed to execute backend operation")]
     Backend(#[source] B),
 
     #[error("failed to draw frame")]
-    DrawFrame(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    DrawFrame(#[source] D),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,38 +1,11 @@
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("failed to draw to terminal")]
-    Draw(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+pub enum Error<E>
+where
+    E: std::error::Error + Sync + Sync + 'static,
+{
+    #[error("failed to execute backend operation")]
+    Backend(#[source] E),
 
-    #[error("failed to flush")]
-    Flush(#[source] std::io::Error),
-
-    #[error("failed to get terminal size")]
-    GetTerminalSize(#[source] std::io::Error),
-
-    #[error("failed to draw background")]
-    DrawBackground(#[source] std::fmt::Error),
-
-    #[error("failed to draw foreground")]
-    DrawForeground(#[source] std::fmt::Error),
-
-    #[error("failed to construct modifier diff")]
-    ModifierDiff(#[source] std::fmt::Error),
-
-    #[error("failed to move cursor to position: {1:?}")]
-    MoveCursor(
-        #[source] Box<dyn std::error::Error + Send + Sync + 'static>,
-        (u16, u16),
-    ),
-
-    #[error("failed to get cursor position")]
-    GetCursosPos(#[source] std::io::Error),
-
-    #[error("failed to show cursor")]
-    ShowCursor(#[source] std::io::Error),
-
-    #[error("failed to hide cursor")]
-    HideCursor(#[source] std::io::Error),
-
-    #[error("failed to clear terminal")]
-    Clear(#[source] std::io::Error),
+    #[error("failed to draw frame")]
+    DrawFrame(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
 #[derive(Debug, thiserror::Error)]
-pub enum Error<E>
+pub enum Error<B, D>
 where
-    E: std::error::Error + Sync + Sync + 'static,
+    B: std::error::Error + Sync + Sync + 'static,
+    D: std::error::Error + Sync + Sync + 'static,
 {
     #[error("failed to execute backend operation")]
-    Backend(#[source] E),
+    Backend(#[source] B),
 
     #[error("failed to draw frame")]
-    DrawFrame(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    DrawFrame(#[source] D),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,38 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to draw to terminal")]
+    Draw(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("failed to flush")]
+    Flush(#[source] std::io::Error),
+
+    #[error("failed to get terminal size")]
+    GetTerminalSize(#[source] std::io::Error),
+
+    #[error("failed to draw background")]
+    DrawBackground(#[source] std::fmt::Error),
+
+    #[error("failed to draw foreground")]
+    DrawForeground(#[source] std::fmt::Error),
+
+    #[error("failed to construct modifier diff")]
+    ModifierDiff(#[source] std::fmt::Error),
+
+    #[error("failed to move cursor to position: {1:?}")]
+    MoveCursor(
+        #[source] Box<dyn std::error::Error + Send + Sync + 'static>,
+        (u16, u16),
+    ),
+
+    #[error("failed to get cursor position")]
+    GetCursosPos(#[source] std::io::Error),
+
+    #[error("failed to show cursor")]
+    ShowCursor(#[source] std::io::Error),
+
+    #[error("failed to hide cursor")]
+    HideCursor(#[source] std::io::Error),
+
+    #[error("failed to clear terminal")]
+    Clear(#[source] std::io::Error),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@
 
 pub mod backend;
 pub mod buffer;
+mod error;
 pub mod layout;
 pub mod style;
 pub mod symbols;
@@ -156,4 +157,5 @@ pub mod terminal;
 pub mod text;
 pub mod widgets;
 
+pub use self::error::Error;
 pub use self::terminal::{Frame, Terminal, TerminalOptions, Viewport};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,13 @@
 //! screen, hiding the cursor, etc.
 //!
 //! ```rust,no_run
+//! use anyhow::Result;
 //! use std::io;
 //! use tui::Terminal;
 //! use tui::backend::TermionBackend;
 //! use termion::raw::IntoRawMode;
 //!
-//! fn main() -> Result<(), io::Error> {
+//! fn main() -> Result<()> {
 //!     let stdout = io::stdout().into_raw_mode()?;
 //!     let backend = TermionBackend::new(stdout);
 //!     let mut terminal = Terminal::new(backend)?;
@@ -77,14 +78,15 @@
 //! The following example renders a block of the size of the terminal:
 //!
 //! ```rust,no_run
-//! use std::io;
+//! use anyhow::Result;
+//! use std::{convert::Infallible, io};
 //! use termion::raw::IntoRawMode;
 //! use tui::Terminal;
 //! use tui::backend::TermionBackend;
 //! use tui::widgets::{Widget, Block, Borders};
 //! use tui::layout::{Layout, Constraint, Direction};
 //!
-//! fn main() -> Result<(), io::Error> {
+//! fn main() -> Result<()> {
 //!     let stdout = io::stdout().into_raw_mode()?;
 //!     let backend = TermionBackend::new(stdout);
 //!     let mut terminal = Terminal::new(backend)?;
@@ -94,6 +96,7 @@
 //!             .title("Block")
 //!             .borders(Borders::ALL);
 //!         f.render_widget(block, size);
+//!         Ok::<_, Infallible>(())
 //!     })?;
 //!     Ok(())
 //! }
@@ -106,14 +109,15 @@
 //! full customization. And `Layout` is no exception:
 //!
 //! ```rust,no_run
-//! use std::io;
+//! use anyhow::Result;
+//! use std::{convert::Infallible, io};
 //! use termion::raw::IntoRawMode;
 //! use tui::Terminal;
 //! use tui::backend::TermionBackend;
 //! use tui::widgets::{Widget, Block, Borders};
 //! use tui::layout::{Layout, Constraint, Direction};
 //!
-//! fn main() -> Result<(), io::Error> {
+//! fn main() -> Result<()> {
 //!     let stdout = io::stdout().into_raw_mode()?;
 //!     let backend = TermionBackend::new(stdout);
 //!     let mut terminal = Terminal::new(backend)?;
@@ -137,6 +141,7 @@
 //!              .title("Block 2")
 //!              .borders(Borders::ALL);
 //!         f.render_widget(block, chunks[1]);
+//!         Ok::<_, Infallible>(())
 //!     })?;
 //!     Ok(())
 //! }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -3,8 +3,8 @@ use crate::{
     buffer::Buffer,
     layout::Rect,
     widgets::{StatefulWidget, Widget},
+    Error,
 };
-use std::io;
 
 #[derive(Debug, Clone, PartialEq)]
 /// UNSTABLE
@@ -176,7 +176,7 @@ where
 {
     /// Wrapper around Terminal initialization. Each buffer is initialized with a blank string and
     /// default colors for the foreground and the background
-    pub fn new(backend: B) -> io::Result<Terminal<B>> {
+    pub fn new(backend: B) -> Result<Terminal<B>, Error> {
         let size = backend.size()?;
         Terminal::with_options(
             backend,
@@ -190,7 +190,7 @@ where
     }
 
     /// UNSTABLE
-    pub fn with_options(backend: B, options: TerminalOptions) -> io::Result<Terminal<B>> {
+    pub fn with_options(backend: B, options: TerminalOptions) -> Result<Terminal<B>, Error> {
         Ok(Terminal {
             backend,
             buffers: [
@@ -225,7 +225,7 @@ where
 
     /// Obtains a difference between the previous and the current buffer and passes it to the
     /// current backend for drawing.
-    pub fn flush(&mut self) -> io::Result<()> {
+    pub fn flush(&mut self) -> Result<(), Error> {
         let previous_buffer = &self.buffers[1 - self.current];
         let current_buffer = &self.buffers[self.current];
         let updates = previous_buffer.diff(current_buffer);
@@ -235,7 +235,7 @@ where
     /// Updates the Terminal so that internal buffers match the requested size. Requested size will
     /// be saved so the size can remain consistent when rendering.
     /// This leads to a full clear of the screen.
-    pub fn resize(&mut self, area: Rect) -> io::Result<()> {
+    pub fn resize(&mut self, area: Rect) -> Result<(), Error> {
         self.buffers[self.current].resize(area);
         self.buffers[1 - self.current].resize(area);
         self.viewport.area = area;
@@ -243,7 +243,7 @@ where
     }
 
     /// Queries the backend for size and resizes if it doesn't match the previous size.
-    pub fn autoresize(&mut self) -> io::Result<()> {
+    pub fn autoresize(&mut self) -> Result<(), Error> {
         if self.viewport.resize_behavior == ResizeBehavior::Auto {
             let size = self.size()?;
             if size != self.viewport.area {
@@ -255,16 +255,17 @@ where
 
     /// Synchronizes terminal size, calls the rendering closure, flushes the current internal state
     /// and prepares for the next draw call.
-    pub fn draw<F>(&mut self, f: F) -> io::Result<CompletedFrame>
+    pub fn draw<F, E>(&mut self, f: F) -> Result<CompletedFrame, Error>
     where
-        F: FnOnce(&mut Frame<B>),
+        E: std::error::Error + Send + Sync + 'static,
+        F: FnOnce(&mut Frame<B>) -> Result<(), E>,
     {
         // Autoresize - otherwise we get glitches if shrinking or potential desync between widgets
         // and the terminal (if growing), which may OOB.
         self.autoresize()?;
 
         let mut frame = self.get_frame();
-        f(&mut frame);
+        f(&mut frame).map_err(|e| Error::Draw(Box::new(e)))?;
         // We can't change the cursor position right away because we have to flush the frame to
         // stdout first. But we also can't keep the frame around, since it holds a &mut to
         // Terminal. Thus, we're taking the important data out of the Frame and dropping it.
@@ -293,28 +294,28 @@ where
         })
     }
 
-    pub fn hide_cursor(&mut self) -> io::Result<()> {
+    pub fn hide_cursor(&mut self) -> Result<(), Error> {
         self.backend.hide_cursor()?;
         self.hidden_cursor = true;
         Ok(())
     }
 
-    pub fn show_cursor(&mut self) -> io::Result<()> {
+    pub fn show_cursor(&mut self) -> Result<(), Error> {
         self.backend.show_cursor()?;
         self.hidden_cursor = false;
         Ok(())
     }
 
-    pub fn get_cursor(&mut self) -> io::Result<(u16, u16)> {
+    pub fn get_cursor(&mut self) -> Result<(u16, u16), Error> {
         self.backend.get_cursor()
     }
 
-    pub fn set_cursor(&mut self, x: u16, y: u16) -> io::Result<()> {
+    pub fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Error> {
         self.backend.set_cursor(x, y)
     }
 
     /// Clear the terminal and force a full redraw on the next draw call.
-    pub fn clear(&mut self) -> io::Result<()> {
+    pub fn clear(&mut self) -> Result<(), Error> {
         self.backend.clear()?;
         // Reset the back buffer to make sure the next update will redraw everything.
         self.buffers[1 - self.current].reset();
@@ -322,7 +323,7 @@ where
     }
 
     /// Queries the real size of the backend.
-    pub fn size(&self) -> io::Result<Rect> {
+    pub fn size(&self) -> Result<Rect, Error> {
         self.backend.size()
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -255,7 +255,7 @@ where
 
     /// Synchronizes terminal size, calls the rendering closure, flushes the current internal state
     /// and prepares for the next draw call.
-    pub fn draw<E, F>(&mut self, f: F) -> Result<CompletedFrame, Error<B::Error>>
+    pub fn draw<E, F>(&mut self, f: F) -> Result<CompletedFrame, Error<B::Error, E>>
     where
         E: std::error::Error + Send + Sync + 'static,
         F: FnOnce(&mut Frame<B>) -> Result<(), E>,
@@ -265,7 +265,7 @@ where
         self.autoresize().map_err(Error::Backend)?;
 
         let mut frame = self.get_frame();
-        f(&mut frame).map_err(|e| Error::DrawFrame(Box::new(e)))?;
+        f(&mut frame).map_err(Error::DrawFrame)?;
         // We can't change the cursor position right away because we have to flush the frame to
         // stdout first. But we also can't keep the frame around, since it holds a &mut to
         // Terminal. Thus, we're taking the important data out of the Frame and dropping it.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -176,8 +176,8 @@ where
 {
     /// Wrapper around Terminal initialization. Each buffer is initialized with a blank string and
     /// default colors for the foreground and the background
-    pub fn new(backend: B) -> Result<Terminal<B>, Error<B::Error>> {
-        let size = backend.size().map_err(Error::Backend)?;
+    pub fn new(backend: B) -> Result<Terminal<B>, B::Error> {
+        let size = backend.size()?;
         Terminal::with_options(
             backend,
             TerminalOptions {
@@ -190,10 +190,7 @@ where
     }
 
     /// UNSTABLE
-    pub fn with_options(
-        backend: B,
-        options: TerminalOptions,
-    ) -> Result<Terminal<B>, Error<B::Error>> {
+    pub fn with_options(backend: B, options: TerminalOptions) -> Result<Terminal<B>, B::Error> {
         Ok(Terminal {
             backend,
             buffers: [
@@ -228,19 +225,17 @@ where
 
     /// Obtains a difference between the previous and the current buffer and passes it to the
     /// current backend for drawing.
-    pub fn flush(&mut self) -> Result<(), Error<B::Error>> {
+    pub fn flush(&mut self) -> Result<(), B::Error> {
         let previous_buffer = &self.buffers[1 - self.current];
         let current_buffer = &self.buffers[self.current];
         let updates = previous_buffer.diff(current_buffer);
-        self.backend
-            .draw(updates.into_iter())
-            .map_err(Error::Backend)
+        self.backend.draw(updates.into_iter())
     }
 
     /// Updates the Terminal so that internal buffers match the requested size. Requested size will
     /// be saved so the size can remain consistent when rendering.
     /// This leads to a full clear of the screen.
-    pub fn resize(&mut self, area: Rect) -> Result<(), Error<B::Error>> {
+    pub fn resize(&mut self, area: Rect) -> Result<(), B::Error> {
         self.buffers[self.current].resize(area);
         self.buffers[1 - self.current].resize(area);
         self.viewport.area = area;
@@ -248,7 +243,7 @@ where
     }
 
     /// Queries the backend for size and resizes if it doesn't match the previous size.
-    pub fn autoresize(&mut self) -> Result<(), Error<B::Error>> {
+    pub fn autoresize(&mut self) -> Result<(), B::Error> {
         if self.viewport.resize_behavior == ResizeBehavior::Auto {
             let size = self.size()?;
             if size != self.viewport.area {
@@ -260,30 +255,30 @@ where
 
     /// Synchronizes terminal size, calls the rendering closure, flushes the current internal state
     /// and prepares for the next draw call.
-    pub fn draw<E, F>(&mut self, f: F) -> Result<CompletedFrame, Error<B::Error>>
+    pub fn draw<E, F>(&mut self, f: F) -> Result<CompletedFrame, Error<B::Error, E>>
     where
         E: std::error::Error + Send + Sync + 'static,
         F: FnOnce(&mut Frame<B>) -> Result<(), E>,
     {
         // Autoresize - otherwise we get glitches if shrinking or potential desync between widgets
         // and the terminal (if growing), which may OOB.
-        self.autoresize()?;
+        self.autoresize().map_err(Error::Backend)?;
 
         let mut frame = self.get_frame();
-        f(&mut frame).map_err(|e| Error::DrawFrame(Box::new(e)))?;
+        f(&mut frame).map_err(Error::DrawFrame)?;
         // We can't change the cursor position right away because we have to flush the frame to
         // stdout first. But we also can't keep the frame around, since it holds a &mut to
         // Terminal. Thus, we're taking the important data out of the Frame and dropping it.
         let cursor_position = frame.cursor_position;
 
         // Draw to stdout
-        self.flush()?;
+        self.flush().map_err(Error::Backend)?;
 
         match cursor_position {
-            None => self.hide_cursor()?,
+            None => self.hide_cursor().map_err(Error::Backend)?,
             Some((x, y)) => {
-                self.show_cursor()?;
-                self.set_cursor(x, y)?;
+                self.show_cursor().map_err(Error::Backend)?;
+                self.set_cursor(x, y).map_err(Error::Backend)?;
             }
         }
 
@@ -299,36 +294,36 @@ where
         })
     }
 
-    pub fn hide_cursor(&mut self) -> Result<(), Error<B::Error>> {
-        self.backend.hide_cursor().map_err(Error::Backend)?;
+    pub fn hide_cursor(&mut self) -> Result<(), B::Error> {
+        self.backend.hide_cursor()?;
         self.hidden_cursor = true;
         Ok(())
     }
 
-    pub fn show_cursor(&mut self) -> Result<(), Error<B::Error>> {
-        self.backend.show_cursor().map_err(Error::Backend)?;
+    pub fn show_cursor(&mut self) -> Result<(), B::Error> {
+        self.backend.show_cursor()?;
         self.hidden_cursor = false;
         Ok(())
     }
 
-    pub fn get_cursor(&mut self) -> Result<(u16, u16), Error<B::Error>> {
-        self.backend.get_cursor().map_err(Error::Backend)
+    pub fn get_cursor(&mut self) -> Result<(u16, u16), B::Error> {
+        self.backend.get_cursor()
     }
 
-    pub fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), Error<B::Error>> {
-        self.backend.set_cursor(x, y).map_err(Error::Backend)
+    pub fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), B::Error> {
+        self.backend.set_cursor(x, y)
     }
 
     /// Clear the terminal and force a full redraw on the next draw call.
-    pub fn clear(&mut self) -> Result<(), Error<B::Error>> {
-        self.backend.clear().map_err(Error::Backend)?;
+    pub fn clear(&mut self) -> Result<(), B::Error> {
+        self.backend.clear()?;
         // Reset the back buffer to make sure the next update will redraw everything.
         self.buffers[1 - self.current].reset();
         Ok(())
     }
 
     /// Queries the real size of the backend.
-    pub fn size(&self) -> Result<Rect, Error<B::Error>> {
-        self.backend.size().map_err(Error::Backend)
+    pub fn size(&self) -> Result<Rect, B::Error> {
+        self.backend.size()
     }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -173,6 +173,7 @@ pub trait Widget {
 ///         // Finally the widget is rendered using the associated state. `events.state` is
 ///         // effectively the only thing that we will "remember" from this draw call.
 ///         f.render_stateful_widget(list, f.size(), &mut events.state);
+///         Ok::<_, std::convert::Infallible>(())
 ///     });
 ///
 ///     // In response to some input events or an external http request or whatever:

--- a/tests/backend_termion.rs
+++ b/tests/backend_termion.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 #[cfg(feature = "termion")]
 #[test]
 fn backend_termion_should_only_write_diffs() -> Result<(), Box<dyn std::error::Error>> {
@@ -20,12 +22,15 @@ fn backend_termion_should_only_write_diffs() -> Result<(), Box<dyn std::error::E
         )?;
         terminal.draw(|f| {
             f.render_widget(Paragraph::new("a"), area);
+            Ok::<_, Infallible>(())
         })?;
         terminal.draw(|f| {
             f.render_widget(Paragraph::new("ab"), area);
+            Ok::<_, Infallible>(())
         })?;
         terminal.draw(|f| {
             f.render_widget(Paragraph::new("abc"), area);
+            Ok::<_, Infallible>(())
         })?;
     }
 

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{convert::Infallible, error::Error};
 use tui::{
     backend::{Backend, TestBackend},
     layout::Rect,
@@ -22,6 +22,7 @@ fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
     let frame = terminal.draw(|f| {
         let paragrah = Paragraph::new("Test");
         f.render_widget(paragrah, f.size());
+        Ok::<_, Infallible>(())
     })?;
     assert_eq!(frame.buffer.get(0, 0).symbol, "T");
     assert_eq!(frame.area, Rect::new(0, 0, 10, 10));
@@ -29,6 +30,7 @@ fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
     let frame = terminal.draw(|f| {
         let paragrah = Paragraph::new("test");
         f.render_widget(paragrah, f.size());
+        Ok::<_, Infallible>(())
     })?;
     assert_eq!(frame.buffer.get(0, 0).symbol, "t");
     assert_eq!(frame.area, Rect::new(0, 0, 8, 8));

--- a/tests/widgets_barchart.rs
+++ b/tests/widgets_barchart.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use tui::backend::TestBackend;
 use tui::buffer::Buffer;
 use tui::widgets::{BarChart, Block, Borders};
@@ -19,6 +20,7 @@ fn widgets_barchart_not_full_below_max_value() {
                     .bar_width(7)
                     .bar_gap(0);
                 f.render_widget(barchart, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
@@ -26,6 +27,7 @@ fn widgets_block_renders() {
                     height: 8,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let mut expected = Buffer::with_lines(vec![
@@ -54,6 +56,7 @@ fn widgets_block_renders_on_small_areas() {
         terminal
             .draw(|f| {
                 f.render_widget(block, area);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
@@ -37,6 +38,7 @@ fn widgets_chart_can_render_on_small_areas() {
                             .labels(create_labels(&["0.0", "1.0"])),
                     );
                 f.render_widget(chart, f.size());
+                Ok::<_, Infallible>(())
             })
             .unwrap();
     };
@@ -79,6 +81,7 @@ fn widgets_chart_can_have_axis_with_zero_length_bounds() {
                     height: 100,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 }
@@ -119,6 +122,7 @@ fn widgets_chart_handles_overflows() {
                     height: 30,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 }
@@ -156,6 +160,7 @@ fn widgets_chart_can_have_empty_datasets() {
                     height: 100,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 }
@@ -226,6 +231,7 @@ fn widgets_chart_can_have_a_legend() {
                     height: 30,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let mut expected = Buffer::with_lines(vec![

--- a/tests/widgets_gauge.rs
+++ b/tests/widgets_gauge.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
@@ -32,6 +33,7 @@ fn widgets_gauge_renders() {
                 .use_unicode(true)
                 .ratio(0.511_313_934_313_1);
             f.render_widget(gauge, chunks[1]);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let mut expected = Buffer::with_lines(vec![
@@ -99,6 +101,7 @@ fn widgets_gauge_renders_no_unicode() {
                 .ratio(0.211_313_934_313_1)
                 .use_unicode(false);
             f.render_widget(gauge, chunks[1]);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let expected = Buffer::with_lines(vec![
@@ -148,6 +151,7 @@ fn widgets_line_gauge_renders() {
                     height: 3,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let mut expected = Buffer::with_lines(vec![

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
@@ -26,6 +28,7 @@ fn widgets_list_should_highlight_the_selected_item() {
                 .highlight_style(Style::default().bg(Color::Yellow))
                 .highlight_symbol(">> ");
             f.render_stateful_widget(list, size, &mut state);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let mut expected = Buffer::with_lines(vec!["   Item 1 ", ">> Item 2 ", "   Item 3 "]);
@@ -81,6 +84,7 @@ fn widgets_list_should_truncate_items() {
                     .block(Block::default().borders(Borders::RIGHT))
                     .highlight_symbol(">> ");
                 f.render_stateful_widget(list, Rect::new(0, 0, 8, 2), &mut state);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&case.expected);

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
@@ -27,6 +29,7 @@ fn widgets_paragraph_can_wrap_its_content() {
                     .alignment(alignment)
                     .wrap(Wrap { trim: true });
                 f.render_widget(paragraph, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -93,6 +96,7 @@ fn widgets_paragraph_renders_double_width_graphemes() {
                 .block(Block::default().borders(Borders::ALL))
                 .wrap(Wrap { trim: true });
             f.render_widget(paragraph, size);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 
@@ -125,6 +129,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
                 .block(Block::default().borders(Borders::ALL))
                 .wrap(Wrap { trim: true });
             f.render_widget(paragraph, size);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 
@@ -158,6 +163,7 @@ fn widgets_paragraph_can_wrap_with_a_trailing_nbsp() {
 
             let paragraph = Paragraph::new(line).block(Block::default().borders(Borders::ALL));
             f.render_widget(paragraph, size);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     terminal.backend().assert_buffer(&expected);
@@ -179,6 +185,7 @@ fn widgets_paragraph_can_scroll_horizontally() {
                     .alignment(alignment)
                     .scroll(scroll);
                 f.render_widget(paragraph, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
@@ -32,6 +34,7 @@ fn widgets_table_column_spacing_can_be_changed() {
                 ])
                 .column_spacing(column_spacing);
                 f.render_widget(table, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -125,6 +128,7 @@ fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
                 .block(Block::default().borders(Borders::ALL))
                 .widths(widths);
                 f.render_widget(table, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -214,6 +218,7 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
                 .widths(widths)
                 .column_spacing(0);
                 f.render_widget(table, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -319,6 +324,7 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
                 .block(Block::default().borders(Borders::ALL))
                 .widths(widths);
                 f.render_widget(table, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -429,6 +435,7 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
                 .widths(widths)
                 .column_spacing(0);
                 f.render_widget(table, size);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -539,6 +546,7 @@ fn widgets_table_can_have_rows_with_multi_lines() {
                 ])
                 .column_spacing(1);
                 f.render_stateful_widget(table, size, state);
+                Ok::<_, Infallible>(())
             })
             .unwrap();
         terminal.backend().assert_buffer(&expected);
@@ -642,6 +650,7 @@ fn widgets_table_can_have_elements_styled_individually() {
             ])
             .column_spacing(1);
             f.render_stateful_widget(table, size, &mut state);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 
@@ -703,6 +712,7 @@ fn widgets_table_should_render_even_if_empty() {
                 ])
                 .column_spacing(1);
             f.render_widget(table, size);
+            Ok::<_, Infallible>(())
         })
         .unwrap();
 

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use tui::{
     backend::TestBackend, buffer::Buffer, layout::Rect, symbols, text::Spans, widgets::Tabs,
     Terminal,
@@ -19,6 +20,7 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
                     height: 1,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let expected = Buffer::with_lines(vec![" "]);
@@ -41,6 +43,7 @@ fn widgets_tabs_should_truncate_the_last_item() {
                     height: 1,
                 },
             );
+            Ok::<_, Infallible>(())
         })
         .unwrap();
     let expected = Buffer::with_lines(vec![format!(" Tab1 {} T ", symbols::line::VERTICAL)]);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->

This PR is a rewrite of the way that `tui-rs` handles errors.

Currently the callback passed to `Terminal::draw` cannot return errors.

If a user has logic inside the callback that is fallible (bounds checking, say), the
only option is to `unwrap`/`expect`/`panic!`, or log an error and try to continue.

The goal of this PR is to allow the callback passed to `Terminal::draw`
to be fallible. This allows users to handle errors inside the callback, and propagates
the errors from the callback to the caller.

There were a few approaches I considered here, in light of needing to handle different error
types from the different backends:

1. A single error type to rule them all, using `Box<dyn std::error::Error + Send + Sync + 'static'>`
   where the types between backends differ. This has the downside of forcing uses who want backend
   specific error variants to downcast, which becomes onerous very quickly.
2. Backend specific error types modeled using an associated `Error` type on the `Backend` trait.

I took approach #2, as it strikes a good balance between usability and strong typing.

### Questions

The `Terminal::draw` method now returns a `Result<_, Error::<B, D>>`, where `B` is a backend
error type and `D` is the closure's error type.

I am on the fence about whether to turn `D` into a `Box<dyn std::error::Error + Send + Sync + 'static'>`
to make using the top-level error type less annoying. I don't _think_ this loses any error information
for the user, since the users has access to the concrete `D` type inside the
closure. It's only when propagating `D` out is the type erased.

### Downsides

This is a major breaking change, and would require all existing `tui-rs` apps to change their
code.

At the very least, `draw` closures will need to return a `Result<(), E>`. The simplest
form of a such a change would be:

```rust
terminal.draw(|frame| {
   // ...

   Ok::<_, std::convert::Infallible>(())
})?;
```

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

These changes can be tested with unit and integration tests available in the repo.

I'm happy to add more tests as needed/desired.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ ] I have added relevant tests.
* [ ] I have documented all new additions.
