### PR TITLE
border! macro for the easy and pretty creation of Borders bitflags.

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -60,6 +60,38 @@ bitflags! {
     }
 }
 
+/// Macro that constructs and returns a [`Borders`] object from TOP, BOTTOM, LEFT, RIGHT, and ALL.
+/// Internally it creates an empty `Borders` object and then inserts each bit flag specified
+/// into it using `Borders::insert()`.
+///
+/// ## Examples
+///
+///```
+/// # use tui::widgets::{Block};
+/// # use tui::style::{Style, Color};
+/// Block::default()
+///     //Construct a `Borders` object and use it in place
+///     .borders(border!(TOP, BOTTOM))
+///
+/// //`border!` can be called with any order of individual sides
+/// let bottom_first = border!(BOTTOM, LEFT, TOP);
+/// //with the ALL keyword which works as expected
+/// let all = border!(ALL);
+/// //or with nothing at all to return `Borders::empty()`.
+/// let empty = border!();
+///
+///```
+#[macro_export]
+macro_rules! border {
+    ( $($b:tt), *) => {{
+            let mut border = Borders::empty();
+            $(
+               border.insert(Borders::$b);
+            )*
+            border
+    }};
+}
+
 /// Base requirements for a Widget
 pub trait Widget {
     /// Draws the current state of the widget in the given buffer. That the only method required to

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -67,7 +67,7 @@ bitflags! {
 /// ## Examples
 ///
 ///```
-/// # use tui::widgets::{Block};
+/// # use tui::widgets::{Block, Borders};
 /// # use tui::style::{Style, Color};
 /// # use tui::border;
 ///

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -60,7 +60,7 @@ bitflags! {
     }
 }
 
-/// Macro that constructs and returns a [`Borders`] object from TOP, BOTTOM, LEFT, RIGHT, and ALL.
+/// Macro that constructs and returns a [`Borders`] object from TOP, BOTTOM, LEFT, RIGHT, NONE, and ALL.
 /// Internally it creates an empty `Borders` object and then inserts each bit flag specified
 /// into it using `Borders::insert()`.
 ///
@@ -77,19 +77,22 @@ bitflags! {
 /// let bottom_first = border!(BOTTOM, LEFT, TOP);
 /// //with the ALL keyword which works as expected
 /// let all = border!(ALL);
-/// //or with nothing at all to return `Borders::empty()`.
-/// let empty = border!();
+/// //or with nothing to return a `Borders::NONE' bitflag.
+/// let none = border!(NONE);
 ///
 ///```
 #[macro_export]
 macro_rules! border {
-    ( $($b:tt), *) => {{
+    ( $($b:tt), +) => {{
             let mut border = Borders::empty();
             $(
                border.insert(Borders::$b);
             )*
             border
     }};
+    () =>{
+        Borders::NONE
+    }
 }
 
 /// Base requirements for a Widget

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -71,7 +71,7 @@ bitflags! {
 /// # use tui::style::{Style, Color};
 /// Block::default()
 ///     //Construct a `Borders` object and use it in place
-///     .borders(border!(TOP, BOTTOM))
+///     .borders(border!(TOP, BOTTOM));
 ///
 /// //`border!` can be called with any order of individual sides
 /// let bottom_first = border!(BOTTOM, LEFT, TOP);

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -69,6 +69,8 @@ bitflags! {
 ///```
 /// # use tui::widgets::{Block};
 /// # use tui::style::{Style, Color};
+/// # use tui::border;
+///
 /// Block::default()
 ///     //Construct a `Borders` object and use it in place
 ///     .borders(border!(TOP, BOTTOM));

--- a/tests/border_macro.rs
+++ b/tests/border_macro.rs
@@ -1,7 +1,4 @@
-use tui::{
-    border,
-    widgets::{Block, Borders},
-};
+use tui::{border, widgets::Borders};
 
 #[test]
 fn border_empty_test() {

--- a/tests/border_macro.rs
+++ b/tests/border_macro.rs
@@ -11,12 +11,12 @@ use tui::{
 
 #[test]
 fn border_empty_test() {
-    let empty = Borders::empty();
+    let empty = Borders::NONE;
     assert_eq!(empty, border!());
 }
 #[test]
 fn border_all_test() {
-    let all = Borders::all();
+    let all = Borders::ALL;
     assert_eq!(all, border!(ALL));
     assert_eq!(all, border!(TOP, BOTTOM, LEFT, RIGHT));
 }

--- a/tests/border_macro.rs
+++ b/tests/border_macro.rs
@@ -10,12 +10,18 @@ use tui::{
 };
 
 #[test]
-fn border_macro_test() {
+fn border_empty_test() {
     let empty = Borders::empty();
-    let all = Borders::all();
-    let left_right = Borders::from_bits(Borders::LEFT.bits() | Borders::RIGHT.bits());
     assert_eq!(empty, border!());
+}
+#[test]
+fn border_all_test() {
+    let all = Borders::all();
     assert_eq!(all, border!(ALL));
     assert_eq!(all, border!(TOP, BOTTOM, LEFT, RIGHT));
+}
+#[test]
+fn border_left_right_test() {
+    let left_right = Borders::from_bits(Borders::LEFT.bits() | Borders::RIGHT.bits());
     assert_eq!(left_right, Some(border!(RIGHT, LEFT)));
 }

--- a/tests/border_macro.rs
+++ b/tests/border_macro.rs
@@ -1,12 +1,6 @@
 use tui::{
-    backend::TestBackend,
     border,
-    buffer::Buffer,
-    layout::Rect,
-    style::{Color, Style},
-    text::Span,
     widgets::{Block, Borders},
-    Terminal,
 };
 
 #[test]

--- a/tests/border_macro.rs
+++ b/tests/border_macro.rs
@@ -1,0 +1,21 @@
+use tui::{
+    backend::TestBackend,
+    border,
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::Span,
+    widgets::{Block, Borders},
+    Terminal,
+};
+
+#[test]
+fn border_macro_test() {
+    let empty = Borders::empty();
+    let all = Borders::all();
+    let left_right = Borders::from_bits(Borders::LEFT.bits() | Borders::RIGHT.bits());
+    assert_eq!(empty, border!());
+    assert_eq!(all, border!(ALL));
+    assert_eq!(all, border!(TOP, BOTTOM, LEFT, RIGHT));
+    assert_eq!(left_right, Some(border!(RIGHT, LEFT)));
+}


### PR DESCRIPTION
## Description
I have added the border! macro. It can be called with any combination of TOP, BOTTOM, LEFT, RIGHT, NONE, or ALL to return a  widgets::Borders object with the corrosponding flags set. This is helpful because the current methods of creating custom Borders is ugly and long. Further things such as Borders.add() or Borders.remove() do not allowing chaining which makes constructing the border you want either a multiline operation or requires oring Borders objects. This macro is cleaner, shorter, and much more readable. 
Compare:
This is a use of Borders from the widgets::Block documentation
`Block::default()
    .title("Block")
    .borders(Borders::LEFT | Borders::RIGHT)
    .border_style(Style::default().fg(Color::White))
    .border_type(BorderType::Rounded)
    .style(Style::default().bg(Color::Black));`

This is the same code with the border! macro
`Block::default()
    .title("Block")
    .borders(border!(LEFT, RIGHT))
    .border_style(Style::default().fg(Color::White))
    .border_type(BorderType::Rounded)
    .style(Style::default().bg(Color::Black));`

As you can see the second is much easier to read and understand. This is a fairly trivial example but if you need a border with three sides the differences becomes much clearer. `border!(TOP, LEFT, RIGHT)` instead of `Borders::TOP | Borders::LEFT | Borders::RIGHT`. 

The macro also provides a syntactic sugar for Borders::NONE. Instead of calling border!(NONE) or using Borders::NONE directly you can just call border!() which return Borders::NONE. 

Interally the macro functions by calling Borders::empty() and then using .insert() to insert each specified flag. If no flags are specified the macro directly returns Borders::NONE and doesn't waste effort creating an empty Borders and inserting.

I have done my best to add inline documentation to the addition but I'm unsure if I did it correctly/formatted it correctly. it currently passes cargo test but a quick glance over it would be appreciated.

## Testing guidelines
I have added tests for the macro to [tests](../tests/) in border_macro.rs. These include tests for ALL, specific sides, and the syntactic sugar for NONE: border!(). All tests pass on debian linux when running cargo test.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
