### PR TITLE
Fix minor grammatical errors in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@
 //! implement your own.
 //!
 //! Each widget follows a builder pattern API providing a default configuration along with methods
-//! to customize them. The widget is then rendered using the [`Frame::render_widget`] which take
-//! your widget instance an area to draw to.
+//! to customize them. The widget is then rendered using [`Frame::render_widget`] which takes
+//! your widget instance and an area to draw to.
 //!
 //! The following example renders a block of the size of the terminal:
 //!


### PR DESCRIPTION


## Description
A missing "and" after "an" (which I do all the time) and some tense clarification for some of the docs

## Testing guidelines
no testing should be needed

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
