### PR TITLE
refactor(examples): remove exit key from Events handler

### DIFF
--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut terminal = Terminal::new(backend)?;
 
     // Setup event handlers
-    let mut events = Events::new();
+    let events = Events::new();
 
     // Create default app state
     let mut app = App::default();
@@ -151,7 +151,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 InputMode::Normal => match input {
                     Key::Char('e') => {
                         app.input_mode = InputMode::Editing;
-                        events.disable_exit_key();
                     }
                     Key::Char('q') => {
                         break;
@@ -170,7 +169,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                     }
                     Key::Esc => {
                         app.input_mode = InputMode::Normal;
-                        events.enable_exit_key();
                     }
                     _ => {}
                 },


### PR DESCRIPTION
## Description

The thread spawned by `Events` to listen for keyboard inputs had knowlegde of
the exit key to exit on its own when it was pressed. It is however a source of
confusion (#491) because the exit behavior is wired in both the event handler
and the input handling performed by the app. In addition, this is not needed as
the thread will exit anyway when the main thread finishes as it is already the
case for the "tick" thread. Therefore, this commit removes both the option to
configure the exit key in the `Events` handler and the option to temporarily
ignore it.

Close #491

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
