### PR TITLE
fix(widgets/gauge): apply label style and avoid overflow on large labels

### DIFF
--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -1,13 +1,14 @@
 #[allow(dead_code)]
 mod util;
 
-use crate::util::event::{Event, Events};
-use std::{error::Error, io};
+use crate::util::event::{Config, Event, Events};
+use std::{error::Error, io, time::Duration};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
+    text::Span,
     widgets::{Block, Borders, Gauge},
     Terminal,
 };
@@ -24,17 +25,17 @@ impl App {
         App {
             progress1: 0,
             progress2: 0,
-            progress3: 0.0,
+            progress3: 0.45,
             progress4: 0,
         }
     }
 
     fn update(&mut self) {
-        self.progress1 += 5;
+        self.progress1 += 1;
         if self.progress1 > 100 {
             self.progress1 = 0;
         }
-        self.progress2 += 10;
+        self.progress2 += 2;
         if self.progress2 > 100 {
             self.progress2 = 0;
         }
@@ -42,7 +43,7 @@ impl App {
         if self.progress3 > 1.0 {
             self.progress3 = 0.0;
         }
-        self.progress4 += 3;
+        self.progress4 += 1;
         if self.progress4 > 100 {
             self.progress4 = 0;
         }
@@ -57,7 +58,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let backend = TermionBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let events = Events::new();
+    let events = Events::with_config(Config {
+        tick_rate: Duration::from_millis(100),
+    });
 
     let mut app = App::new();
 
@@ -91,10 +94,18 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .label(label);
             f.render_widget(gauge, chunks[1]);
 
+            let label = Span::styled(
+                format!("{:.2}%", app.progress3 * 100.0),
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::ITALIC | Modifier::BOLD),
+            );
             let gauge = Gauge::default()
                 .block(Block::default().title("Gauge3").borders(Borders::ALL))
                 .gauge_style(Style::default().fg(Color::Yellow))
-                .ratio(app.progress3);
+                .ratio(app.progress3)
+                .label(label)
+                .use_unicode(true);
             f.render_widget(gauge, chunks[2]);
 
             let label = format!("{}/100", app.progress2);
@@ -106,8 +117,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .add_modifier(Modifier::ITALIC),
                 )
                 .percent(app.progress4)
-                .label(label)
-                .use_unicode(true);
+                .label(label);
             f.render_widget(gauge, chunks[3]);
         })?;
 


### PR DESCRIPTION
## Description

Refactor the gauge render logic to fix two bugs:
* the label style was not applied
* using a label larger than the gauge width triggered a panic

Close #480 

## Testing guidelines
* Two integration tests have been added
* Run `cargo run --example gauge`

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
