### PR TITLE
state: adds offset access and manipulation

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -14,6 +14,16 @@ pub struct ListState {
 }
 
 impl ListState {
+    /// Returns the offset.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Mutably returns the offset.
+    pub fn offset_mut(&mut self) -> &mut usize {
+        &mut self.offset
+    }
+
     pub fn selected(&self) -> Option<usize> {
         self.selected
     }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -342,6 +342,16 @@ pub struct TableState {
 }
 
 impl TableState {
+    /// Returns the offset.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Mutably returns the offset.
+    pub fn offset_mut(&mut self) -> &mut usize {
+        &mut self.offset
+    }
+
     pub fn selected(&self) -> Option<usize> {
         self.selected
     }


### PR DESCRIPTION
## Description

Adds offset access and manipulation. Fixes #495. 

## Testing guidelines

I have a few structs that keep the table state. I use this `trait ScrollableTable` for each of these to attach actions like scroll up/down, etc. I've added this `fn recenter` to test offset manipulation. `ListState` should be pretty much analogously. 

Note that I haven't added tests per se, because I think that these kinds of accessor/mutator functions are quite obvious. 

```rust
use tui::layout::Rect;
use tui::widgets::TableState;

pub trait ScrollableTable {
    fn size(&self) -> Rect;
    fn state(&self) -> &TableState;
    fn state_mut(&mut self) -> &mut TableState;

    fn recenter(&mut self) {
        if let Some(selected) = self.state().selected() {
            let height = self.size().height as usize;

            let offset = self.state_mut().offset_mut();
            *offset = selected.saturating_sub(height / 2);
        }
    }
}
```

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ ] I have added relevant tests.
* [x] I have documented all new additions.
