### PR TITLE
Allow specifying margins for Paragraph widget

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -51,6 +51,33 @@ pub struct Margin {
     pub horizontal: u16,
 }
 
+impl Margin {
+    pub fn both(mut self, margin: u16) -> Self {
+        self.vertical = margin;
+        self.horizontal = margin;
+        self
+    }
+
+    pub fn horizontal(mut self, margin: u16) -> Self {
+        self.horizontal = margin;
+        self
+    }
+
+    pub fn vertical(mut self, margin: u16) -> Self {
+        self.vertical = margin;
+        self
+    }
+}
+
+impl Default for Margin {
+    fn default() -> Self {
+        Margin {
+            vertical: 0,
+            horizontal: 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Alignment {
     Left,
@@ -73,10 +100,7 @@ impl Default for Layout {
     fn default() -> Layout {
         Layout {
             direction: Direction::Vertical,
-            margin: Margin {
-                horizontal: 0,
-                vertical: 0,
-            },
+            margin: Default::default(),
             constraints: Vec::new(),
         }
     }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -27,7 +27,7 @@ fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) 
 /// # use tui::text::{Text, Spans, Span};
 /// # use tui::widgets::{Block, Borders, Paragraph, Wrap};
 /// # use tui::style::{Style, Color, Modifier};
-/// # use tui::layout::{Alignment};
+/// # use tui::layout::{Alignment, Margin};
 /// let text = vec![
 ///     Spans::from(vec![
 ///         Span::raw("First"),
@@ -40,7 +40,8 @@ fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) 
 ///     .block(Block::default().title("Paragraph").borders(Borders::ALL))
 ///     .style(Style::default().fg(Color::White).bg(Color::Black))
 ///     .alignment(Alignment::Center)
-///     .wrap(Wrap { trim: true });
+///     .wrap(Wrap { trim: true })
+///     .margin(Margin::default().both(1));
 /// ```
 #[derive(Debug, Clone)]
 pub struct Paragraph<'a> {

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::Buffer,
-    layout::{Alignment, Rect},
+    layout::{Alignment, Margin, Rect},
     style::Style,
     text::{StyledGrapheme, Text},
     widgets::{
@@ -56,6 +56,8 @@ pub struct Paragraph<'a> {
     scroll: (u16, u16),
     /// Alignment of the text
     alignment: Alignment,
+    /// Margin around the text
+    margin: Margin,
 }
 
 /// Describes how to wrap text across lines.
@@ -103,6 +105,7 @@ impl<'a> Paragraph<'a> {
             text: text.into(),
             scroll: (0, 0),
             alignment: Alignment::Left,
+            margin: Default::default(),
         }
     }
 
@@ -130,6 +133,11 @@ impl<'a> Paragraph<'a> {
         self.alignment = alignment;
         self
     }
+
+    pub fn margin(mut self, margin: Margin) -> Paragraph<'a> {
+        self.margin = margin;
+        self
+    }
 }
 
 impl<'a> Widget for Paragraph<'a> {
@@ -142,7 +150,8 @@ impl<'a> Widget for Paragraph<'a> {
                 inner_area
             }
             None => area,
-        };
+        }
+        .inner(&self.margin);
 
         if text_area.height < 1 {
             return;

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -1,7 +1,7 @@
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
-    layout::Alignment,
+    layout::{Alignment, Margin},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph, Wrap},
     Terminal,
@@ -209,6 +209,107 @@ fn widgets_paragraph_can_scroll_horizontally() {
             "│段落现在可以水平滚│",
             "│Paragraph can scro│",
             "│        Short line│",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_respects_margins() {
+    let test_case = |margin, expected| {
+        let backend = TestBackend::new(20, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|f| {
+                let size = f.size();
+                let text = vec![Spans::from(SAMPLE_STRING)];
+                let paragraph = Paragraph::new(text)
+                    .block(Block::default().borders(Borders::ALL))
+                    .wrap(Wrap { trim: true })
+                    .margin(margin);
+                f.render_widget(paragraph, size);
+            })
+            .unwrap();
+        terminal.backend().assert_buffer(&expected);
+    };
+
+    test_case(
+        Margin::default(),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│The library is    │",
+            "│based on the      │",
+            "│principle of      │",
+            "│immediate         │",
+            "│rendering with    │",
+            "│intermediate      │",
+            "│buffers. This     │",
+            "│means that at each│",
+            "└──────────────────┘",
+        ]),
+    );
+
+    test_case(
+        Margin::default().horizontal(1),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│ The library is   │",
+            "│ based on the     │",
+            "│ principle of     │",
+            "│ immediate        │",
+            "│ rendering with   │",
+            "│ intermediate     │",
+            "│ buffers. This    │",
+            "│ means that at    │",
+            "└──────────────────┘",
+        ]),
+    );
+
+    test_case(
+        Margin::default().vertical(1),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│                  │",
+            "│The library is    │",
+            "│based on the      │",
+            "│principle of      │",
+            "│immediate         │",
+            "│rendering with    │",
+            "│intermediate      │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+
+    test_case(
+        Margin::default().both(1),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│                  │",
+            "│ The library is   │",
+            "│ based on the     │",
+            "│ principle of     │",
+            "│ immediate        │",
+            "│ rendering with   │",
+            "│ intermediate     │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+
+    test_case(
+        Margin::default().horizontal(9).vertical(4),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│                  │",
+            "│                  │",
+            "│                  │",
             "│                  │",
             "│                  │",
             "│                  │",


### PR DESCRIPTION
## Description
Margins can now be specified around the text in a `Paragraph` widget via the `.margin(...)` builder method which accepts a `Margin` struct.
There was some discussion last year in #299 about adding margins to all widgets, though it seems like there hasn't been much progress in that respect.
This PR is essentially a sibling to #319, which does the same for the `Tabs` widget instead.

I've only added a single test for now, though if you'd like more to test if the margins play well with other properties such as alignment and text wrapping, I'd be happy to do so!

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
