### PR TITLE
Fix for table panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## To be released
 
+### Fixes
+
+* Some combinations of `Table` widths and `Rect` width would cause a panic due to accessing area
+outside the buffer - (#470)
+
 ## v0.15.0 - 2021-05-02
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Florian Dehau <work@fdehau.com>"]
 description = """
 A library to build rich terminal user interfaces or dashboards

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -353,8 +353,10 @@ impl Buffer {
     }
 
     pub fn set_style(&mut self, area: Rect, style: Style) {
+        // Ensure styling doesn't overflow buffer - https://github.com/fdehau/tui-rs/issues/470
+        let right = min(area.right(), self.area.width);
         for y in area.top()..area.bottom() {
-            for x in area.left()..area.right() {
+            for x in area.left()..right {
                 self.get_mut(x, y).set_style(style);
             }
         }


### PR DESCRIPTION
## Description

This is an initial fix for issue #470.

After walking through one of the cases that caused the panic in a debugger, I found that it was due to a miscalculation (it seems like a rounding issue) in the column widths from the `cassowary` solver. I don't fully understand the parameters for this solver and as such I didn't feel comfortable trying to implement a fix into the `get_column_widths` function. Changing the solver also seems to have potential knock-on effects in how all tables are rendered, which sounds like a disruptive change.

So, I tried to make a minimal fix by simply checking for overflow in the `set_style` function and clamping the value if there would have been an overflow. 

I'm not exactly sure if this is a completely robust solution, but it seems to work for the two test cases we have so far.

@fdehau would love your thoughts on how robust of a fix this is!

## Testing guidelines

I added the two example tables that were causing a panic from the issue in `widgets_table_columns_dont_panic` test function. All this test does is render the tables and ensures a panic doesn't occur. It doesn't verify the output of the table.

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [X] I have added relevant tests.
* [ ] I have documented all new additions.
