### PR TITLE
fix(widgets/chart): remove panics with long axis labels

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -5,7 +5,6 @@ use crate::{
     text::Text,
     widgets::{Block, StatefulWidget, Widget},
 };
-use std::iter::{self, Iterator};
 use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Clone)]
@@ -185,9 +184,7 @@ impl<'a> StatefulWidget for List<'a> {
         state.offset = start;
 
         let highlight_symbol = self.highlight_symbol.unwrap_or("");
-        let blank_symbol = iter::repeat(" ")
-            .take(highlight_symbol.width())
-            .collect::<String>();
+        let blank_symbol = " ".repeat(highlight_symbol.width());
 
         let mut current_height = 0;
         let has_selection = state.selected.is_some();

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -10,10 +10,7 @@ use cassowary::{
     WeightedRelation::*,
     {Expression, Solver},
 };
-use std::{
-    collections::HashMap,
-    iter::{self, Iterator},
-};
+use std::collections::HashMap;
 use unicode_width::UnicodeWidthStr;
 
 /// A [`Cell`] contains the [`Text`] to be displayed in a [`Row`] of a [`Table`].
@@ -427,9 +424,7 @@ impl<'a> StatefulWidget for Table<'a> {
         let has_selection = state.selected.is_some();
         let columns_widths = self.get_columns_widths(table_area.width, has_selection);
         let highlight_symbol = self.highlight_symbol.unwrap_or("");
-        let blank_symbol = iter::repeat(" ")
-            .take(highlight_symbol.width())
-            .collect::<String>();
+        let blank_symbol = " ".repeat(highlight_symbol.width());
         let mut current_height = 0;
         let mut rows_height = table_area.height;
 


### PR DESCRIPTION
## Description
* clamp the width of the first x axis label to not go above the width between the chart left border and the y axis.
* clamp the width of all other x axis labels to not go above the width between each x axis tick.
* clamp the width of all y axis labels to not go above 1/3 of the chart area.
 
Fixes #490

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
