### PR TITLE
fix(widgets): avoid offset panic in `Table` and `List` when input changes

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -128,6 +128,44 @@ impl<'a> List<'a> {
         self.start_corner = corner;
         self
     }
+
+    fn get_items_bounds(
+        &self,
+        selected: Option<usize>,
+        offset: usize,
+        max_height: usize,
+    ) -> (usize, usize) {
+        let offset = offset.min(self.items.len().saturating_sub(1));
+        let mut start = offset;
+        let mut end = offset;
+        let mut height = 0;
+        for item in self.items.iter().skip(offset) {
+            if height + item.height() > max_height {
+                break;
+            }
+            height += item.height();
+            end += 1;
+        }
+
+        let selected = selected.unwrap_or(0).min(self.items.len() - 1);
+        while selected >= end {
+            height = height.saturating_add(self.items[end].height());
+            end += 1;
+            while height > max_height {
+                height = height.saturating_sub(self.items[start].height());
+                start += 1;
+            }
+        }
+        while selected < start {
+            start -= 1;
+            height = height.saturating_add(self.items[start].height());
+            while height > max_height {
+                end -= 1;
+                height = height.saturating_sub(self.items[end].height());
+            }
+        }
+        (start, end)
+    }
 }
 
 impl<'a> StatefulWidget for List<'a> {
@@ -153,34 +191,7 @@ impl<'a> StatefulWidget for List<'a> {
         }
         let list_height = list_area.height as usize;
 
-        let mut start = state.offset;
-        let mut end = state.offset;
-        let mut height = 0;
-        for item in self.items.iter().skip(state.offset) {
-            if height + item.height() > list_height {
-                break;
-            }
-            height += item.height();
-            end += 1;
-        }
-
-        let selected = state.selected.unwrap_or(0).min(self.items.len() - 1);
-        while selected >= end {
-            height = height.saturating_add(self.items[end].height());
-            end += 1;
-            while height > list_height {
-                height = height.saturating_sub(self.items[start].height());
-                start += 1;
-            }
-        }
-        while selected < start {
-            start -= 1;
-            height = height.saturating_add(self.items[start].height());
-            while height > list_height {
-                end -= 1;
-                height = height.saturating_sub(self.items[end].height());
-            }
-        }
+        let (start, end) = self.get_items_bounds(state.selected, state.offset, list_height);
         state.offset = start;
 
         let highlight_symbol = self.highlight_symbol.unwrap_or("");

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -302,6 +302,7 @@ impl<'a> Table<'a> {
         offset: usize,
         max_height: u16,
     ) -> (usize, usize) {
+        let offset = offset.min(self.rows.len().saturating_sub(1));
         let mut start = offset;
         let mut end = offset;
         let mut height = 0;

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -749,3 +749,75 @@ fn widgets_table_columns_dont_panic() {
     state.select(Some(0));
     test_case(&mut state, table1.clone(), table1_width);
 }
+
+#[test]
+fn widgets_table_should_clamp_offset_if_rows_are_removed() {
+    let backend = TestBackend::new(30, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut state = TableState::default();
+
+    // render with 6 items => offset will be at 2
+    state.select(Some(5));
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(vec![
+                Row::new(vec!["Row01", "Row02", "Row03"]),
+                Row::new(vec!["Row11", "Row12", "Row13"]),
+                Row::new(vec!["Row21", "Row22", "Row23"]),
+                Row::new(vec!["Row31", "Row32", "Row33"]),
+                Row::new(vec!["Row41", "Row42", "Row43"]),
+                Row::new(vec!["Row51", "Row52", "Row53"]),
+            ])
+            .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+            .block(Block::default().borders(Borders::ALL))
+            .widths(&[
+                Constraint::Length(5),
+                Constraint::Length(5),
+                Constraint::Length(5),
+            ])
+            .column_spacing(1);
+            f.render_stateful_widget(table, size, &mut state);
+        })
+        .unwrap();
+    let expected = Buffer::with_lines(vec![
+        "┌────────────────────────────┐",
+        "│Head1 Head2 Head3           │",
+        "│                            │",
+        "│Row21 Row22 Row23           │",
+        "│Row31 Row32 Row33           │",
+        "│Row41 Row42 Row43           │",
+        "│Row51 Row52 Row53           │",
+        "└────────────────────────────┘",
+    ]);
+    terminal.backend().assert_buffer(&expected);
+
+    // render with 1 item => offset will be at 1
+    state.select(Some(1));
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let table = Table::new(vec![Row::new(vec!["Row31", "Row32", "Row33"])])
+                .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
+                .block(Block::default().borders(Borders::ALL))
+                .widths(&[
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                ])
+                .column_spacing(1);
+            f.render_stateful_widget(table, size, &mut state);
+        })
+        .unwrap();
+    let expected = Buffer::with_lines(vec![
+        "┌────────────────────────────┐",
+        "│Head1 Head2 Head3           │",
+        "│                            │",
+        "│Row31 Row32 Row33           │",
+        "│                            │",
+        "│                            │",
+        "│                            │",
+        "└────────────────────────────┘",
+    ]);
+    terminal.backend().assert_buffer(&expected);
+}


### PR DESCRIPTION
## Description
Avoid panics in `Table` and `List` when the input rows or items are shortened between two frames and the previous offset is now out of bounds.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
