### PR TITLE
feat(layout): add support for multiple weighted constraints by chunks

### DIFF
--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     widgets::{BarChart, Block, Borders},
     Terminal,
@@ -73,7 +73,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(f.size());
             let barchart = BarChart::default()
                 .block(Block::default().title("Data1").borders(Borders::ALL))
@@ -85,7 +88,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(chunks[1]);
 
             let barchart = BarChart::default()

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, BorderType, Borders},
@@ -42,13 +42,19 @@ fn main() -> Result<(), Box<dyn Error>> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(4)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(f.size());
 
             // Top two inner blocks
             let top_chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(chunks[0]);
 
             // Top left inner block with green background
@@ -75,7 +81,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Bottom two inner blocks
             let bottom_chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(chunks[1]);
 
             // Bottom left block with all default borders

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io, time::Duration};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Rect, Unit},
     style::Color,
     widgets::{
         canvas::{Canvas, Map, MapResolution, Rectangle},
@@ -94,7 +94,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(f.size());
             let canvas = Canvas::default()
                 .block(Block::default().borders(Borders::ALL).title("World"))

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -9,7 +9,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     symbols,
     text::Span,
@@ -83,14 +83,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             let size = f.size();
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints(
-                    [
-                        Constraint::Ratio(1, 3),
-                        Constraint::Ratio(1, 3),
-                        Constraint::Ratio(1, 3),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::eq(Unit::Ratio(1, 3)),
+                    Constraint::eq(Unit::Ratio(1, 3)),
+                    Constraint::eq(Unit::Ratio(1, 3)),
+                ])
                 .split(size);
             let x_labels = vec![
                 Span::styled(

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -1,7 +1,8 @@
 use crate::demo::App;
+use std::iter::FromIterator;
 use tui::{
     backend::Backend,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Constraints, Direction, Layout, Rect, Unit},
     style::{Color, Modifier, Style},
     symbols,
     text::{Span, Spans},
@@ -15,7 +16,13 @@ use tui::{
 
 pub fn draw<B: Backend>(f: &mut Frame<B>, app: &mut App) {
     let chunks = Layout::default()
-        .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
+        .constraints([
+            Constraint::eq(3).weight(10).into(),
+            Constraints::from_iter([
+                Constraint::eq(Unit::Percentage(100)),
+                Constraint::gte(10).weight(10),
+            ]),
+        ])
         .split(f.size());
     let titles = app
         .tabs
@@ -41,14 +48,14 @@ where
     B: Backend,
 {
     let chunks = Layout::default()
-        .constraints(
-            [
-                Constraint::Length(9),
-                Constraint::Min(8),
-                Constraint::Length(7),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::eq(9).weight(10).into(),
+            Constraints::from_iter([
+                Constraint::eq(Unit::Percentage(100)),
+                Constraint::gte(8).weight(10),
+            ]),
+            Constraint::eq(7).weight(10).into(),
+        ])
         .split(area);
     draw_gauges(f, app, chunks[0]);
     draw_charts(f, app, chunks[1]);
@@ -60,14 +67,7 @@ where
     B: Backend,
 {
     let chunks = Layout::default()
-        .constraints(
-            [
-                Constraint::Length(2),
-                Constraint::Length(3),
-                Constraint::Length(1),
-            ]
-            .as_ref(),
-        )
+        .constraints([Constraint::eq(2), Constraint::eq(3), Constraint::eq(1)])
         .margin(1)
         .split(area);
     let block = Block::default().borders(Borders::ALL).title("Graphs");
@@ -114,9 +114,12 @@ where
     B: Backend,
 {
     let constraints = if app.show_chart {
-        vec![Constraint::Percentage(50), Constraint::Percentage(50)]
+        vec![
+            Constraint::eq(Unit::Percentage(50)),
+            Constraint::eq(Unit::Percentage(50)),
+        ]
     } else {
-        vec![Constraint::Percentage(100)]
+        vec![Constraint::eq(Unit::Percentage(100))]
     };
     let chunks = Layout::default()
         .constraints(constraints)
@@ -124,11 +127,17 @@ where
         .split(area);
     {
         let chunks = Layout::default()
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+            .constraints([
+                Constraint::eq(Unit::Percentage(50)),
+                Constraint::eq(Unit::Percentage(50)),
+            ])
             .split(chunks[0]);
         {
             let chunks = Layout::default()
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .direction(Direction::Horizontal)
                 .split(chunks[0]);
 
@@ -302,7 +311,10 @@ where
     B: Backend,
 {
     let chunks = Layout::default()
-        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
+        .constraints([
+            Constraint::eq(Unit::Percentage(30)),
+            Constraint::eq(Unit::Percentage(70)),
+        ])
         .direction(Direction::Horizontal)
         .split(area);
     let up_style = Style::default().fg(Color::Green);
@@ -324,11 +336,7 @@ where
                 .bottom_margin(1),
         )
         .block(Block::default().title("Servers").borders(Borders::ALL))
-        .widths(&[
-            Constraint::Length(15),
-            Constraint::Length(15),
-            Constraint::Length(10),
-        ]);
+        .widths([Constraint::eq(15), Constraint::eq(15), Constraint::eq(10)]);
     f.render_widget(table, chunks[0]);
 
     let map = Canvas::default()
@@ -382,7 +390,10 @@ where
 {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
+        .constraints([
+            Constraint::eq(Unit::Ratio(1, 2)),
+            Constraint::eq(Unit::Ratio(1, 2)),
+        ])
         .split(area);
     let colors = [
         Color::Reset,
@@ -416,10 +427,10 @@ where
         .collect();
     let table = Table::new(items)
         .block(Block::default().title("Colors").borders(Borders::ALL))
-        .widths(&[
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
+        .widths([
+            Constraint::eq(Unit::Ratio(1, 3)),
+            Constraint::eq(Unit::Ratio(1, 3)),
+            Constraint::eq(Unit::Ratio(1, 3)),
         ]);
     f.render_widget(table, chunks[0]);
 }

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io, time::Duration};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, Borders, Gauge},
@@ -69,15 +69,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
-                .constraints(
-                    [
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::eq(Unit::Percentage(25)),
+                    Constraint::eq(Unit::Percentage(25)),
+                    Constraint::eq(Unit::Percentage(25)),
+                    Constraint::eq(Unit::Percentage(25)),
+                ])
                 .split(f.size());
 
             let gauge = Gauge::default()

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     widgets::{Block, Borders},
     Terminal,
 };
@@ -25,14 +25,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         terminal.draw(|f| {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints(
-                    [
-                        Constraint::Percentage(10),
-                        Constraint::Percentage(80),
-                        Constraint::Percentage(10),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::eq(Unit::Percentage(10)),
+                    Constraint::eq(Unit::Percentage(80)),
+                    Constraint::eq(Unit::Percentage(10)),
+                ])
                 .split(f.size());
 
             let block = Block::default().title("Block").borders(Borders::ALL);

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -9,7 +9,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Corner, Direction, Layout},
+    layout::{Constraint, Corner, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
     widgets::{Block, Borders, List, ListItem},
@@ -114,7 +114,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Create two chunks with equal horizontal screen space
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(f.size());
 
             // Iterate through all elements in the `items` app and append some debug text to it.

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
     widgets::{Block, Borders, Paragraph, Wrap},
@@ -42,12 +42,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .margin(5)
                 .constraints(
                     [
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
+                        Constraint::eq(Unit::Percentage(25)),
+                        Constraint::eq(Unit::Percentage(25)),
+                        Constraint::eq(Unit::Percentage(25)),
+                        Constraint::eq(Unit::Percentage(25)),
                     ]
-                    .as_ref(),
                 )
                 .split(size);
 

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -6,7 +6,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect, Unit},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
@@ -18,26 +18,20 @@ use tui::{
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
     let popup_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Percentage((100 - percent_y) / 2),
-                Constraint::Percentage(percent_y),
-                Constraint::Percentage((100 - percent_y) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints(vec![
+            Constraint::eq(Unit::Percentage((100 - percent_y) / 2)),
+            Constraint::eq(Unit::Percentage(percent_y)),
+            Constraint::eq(Unit::Percentage((100 - percent_y) / 2)),
+        ])
         .split(r);
 
     Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Percentage((100 - percent_x) / 2),
-                Constraint::Percentage(percent_x),
-                Constraint::Percentage((100 - percent_x) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints(vec![
+            Constraint::eq(Unit::Percentage((100 - percent_x) / 2)),
+            Constraint::eq(Unit::Percentage(percent_x)),
+            Constraint::eq(Unit::Percentage((100 - percent_x) / 2)),
+        ])
         .split(popup_layout[1])[1]
 }
 
@@ -57,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([Constraint::eq(Unit::Percentage(50)), Constraint::eq(Unit::Percentage(50))])
                 .split(size);
 
                 let s = "Veeeeeeeeeeeeeeeery    loooooooooooooooooong   striiiiiiiiiiiiiiiiiiiiiiiiiing.   ";

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -9,7 +9,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     style::{Color, Style},
     widgets::{Block, Borders, Sparkline},
     Terminal,
@@ -68,15 +68,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
-                .constraints(
-                    [
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(7),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::eq(3).weight(10),
+                    Constraint::eq(3).weight(10),
+                    Constraint::eq(7).weight(10),
+                    Constraint::eq(Unit::Percentage(100)),
+                ])
                 .split(f.size());
             let sparkline = Sparkline::default()
                 .block(

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -9,7 +9,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
     widgets::{Block, Borders, Tabs},
@@ -42,7 +42,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(5)
-                .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
+                .constraints([
+                    Constraint::eq(3).weight(10),
+                    Constraint::eq(Unit::Percentage(100)),
+                ])
                 .split(size);
 
             let block = Block::default().style(Style::default().bg(Color::White).fg(Color::Black));

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -18,7 +18,7 @@ use std::{error::Error, io};
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{
     backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Unit},
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, List, ListItem, Paragraph},
@@ -71,14 +71,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
-                .constraints(
-                    [
-                        Constraint::Length(1),
-                        Constraint::Length(3),
-                        Constraint::Min(1),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::eq(1).weight(10),
+                    Constraint::eq(3).weight(10),
+                    Constraint::eq(Unit::Percentage(100)),
+                ])
                 .split(f.size());
 
             let (msg, style) = match app.input_mode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 //! use tui::Terminal;
 //! use tui::backend::TermionBackend;
 //! use tui::widgets::{Widget, Block, Borders};
-//! use tui::layout::{Layout, Constraint, Direction};
+//! use tui::layout::{Layout, Constraint, Direction, Unit};
 //!
 //! fn main() -> Result<(), io::Error> {
 //!     let stdout = io::stdout().into_raw_mode()?;
@@ -123,10 +123,10 @@
 //!             .margin(1)
 //!             .constraints(
 //!                 [
-//!                     Constraint::Percentage(10),
-//!                     Constraint::Percentage(80),
-//!                     Constraint::Percentage(10)
-//!                 ].as_ref()
+//!                     Constraint::eq(Unit::Percentage(10)),
+//!                     Constraint::eq(Unit::Percentage(80)),
+//!                     Constraint::eq(Unit::Percentage(10))
+//!                 ]
 //!             )
 //!             .split(f.size());
 //!         let block = Block::default()
@@ -142,10 +142,7 @@
 //! }
 //! ```
 //!
-//! This let you describe responsive terminal UI by nesting layouts. You should note that by
-//! default the computed layout tries to fill the available space completely. So if for any reason
-//! you might need a blank space somewhere, try to pass an additional constraint and don't use the
-//! corresponding area.
+//! This let you describe responsive terminal UI by nesting layouts.
 
 pub mod backend;
 pub mod buffer;

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::Buffer,
-    layout::{Constraint, Rect},
+    layout::{Rect, Unit},
     style::{Color, Style},
     symbols,
     text::{Span, Spans},
@@ -225,7 +225,7 @@ pub struct Chart<'a> {
     /// The widget base style
     style: Style,
     /// Constraints used to determine whether the legend should be shown or not
-    hidden_legend_constraints: (Constraint, Constraint),
+    hidden_legend_constraints: (Unit, Unit),
 }
 
 impl<'a> Chart<'a> {
@@ -236,7 +236,7 @@ impl<'a> Chart<'a> {
             y_axis: Axis::default(),
             style: Default::default(),
             datasets,
-            hidden_legend_constraints: (Constraint::Ratio(1, 4), Constraint::Ratio(1, 4)),
+            hidden_legend_constraints: (Unit::Ratio(1, 4), Unit::Ratio(1, 4)),
         }
     }
 
@@ -266,17 +266,17 @@ impl<'a> Chart<'a> {
     ///
     /// ```
     /// # use tui::widgets::Chart;
-    /// # use tui::layout::Constraint;
+    /// # use tui::layout::Unit;
     /// let constraints = (
-    ///     Constraint::Ratio(1, 3),
-    ///     Constraint::Ratio(1, 4)
+    ///     Unit::Ratio(1, 3),
+    ///     Unit::Ratio(1, 4)
     /// );
     /// // Hide the legend when either its width is greater than 33% of the total widget width
     /// // or if its height is greater than 25% of the total widget height.
     /// let _chart: Chart = Chart::new(vec![])
     ///     .hidden_legend_constraints(constraints);
     /// ```
-    pub fn hidden_legend_constraints(mut self, constraints: (Constraint, Constraint)) -> Chart<'a> {
+    pub fn hidden_legend_constraints(mut self, constraints: (Unit, Unit)) -> Chart<'a> {
         self.hidden_legend_constraints = constraints;
         self
     }
@@ -562,7 +562,7 @@ mod tests {
 
     struct LegendTestCase {
         chart_area: Rect,
-        hidden_legend_constraints: (Constraint, Constraint),
+        hidden_legend_constraints: (Unit, Unit),
         legend_area: Option<Rect>,
     }
 
@@ -572,12 +572,12 @@ mod tests {
         let cases = [
             LegendTestCase {
                 chart_area: Rect::new(0, 0, 100, 100),
-                hidden_legend_constraints: (Constraint::Ratio(1, 4), Constraint::Ratio(1, 4)),
+                hidden_legend_constraints: (Unit::Ratio(1, 4), Unit::Ratio(1, 4)),
                 legend_area: Some(Rect::new(88, 0, 12, 12)),
             },
             LegendTestCase {
                 chart_area: Rect::new(0, 0, 100, 100),
-                hidden_legend_constraints: (Constraint::Ratio(1, 10), Constraint::Ratio(1, 4)),
+                hidden_legend_constraints: (Unit::Ratio(1, 10), Unit::Ratio(1, 4)),
                 legend_area: None,
             },
         ];

--- a/tests/widgets_gauge.rs
+++ b/tests/widgets_gauge.rs
@@ -1,7 +1,7 @@
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Rect, Unit},
     style::{Color, Modifier, Style},
     symbols,
     text::Span,
@@ -18,7 +18,10 @@ fn widgets_gauge_renders() {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(f.size());
 
             let gauge = Gauge::default()
@@ -87,7 +90,10 @@ fn widgets_gauge_renders_no_unicode() {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(2)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .constraints([
+                    Constraint::eq(Unit::Percentage(50)),
+                    Constraint::eq(Unit::Percentage(50)),
+                ])
                 .split(f.size());
 
             let gauge = Gauge::default()

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -1,7 +1,7 @@
 use tui::{
     backend::TestBackend,
     buffer::Buffer,
-    layout::Constraint,
+    layout::{Constraint, Unit},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
     widgets::{Block, Borders, Cell, Row, Table, TableState},
@@ -25,11 +25,7 @@ fn widgets_table_column_spacing_can_be_changed() {
                 ])
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
                 .block(Block::default().borders(Borders::ALL))
-                .widths(&[
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                ])
+                .widths([Constraint::eq(5), Constraint::eq(5), Constraint::eq(5)])
                 .column_spacing(column_spacing);
                 f.render_widget(table, size);
             })
@@ -132,11 +128,7 @@ fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
 
     // columns of zero width show nothing
     test_case(
-        &[
-            Constraint::Length(0),
-            Constraint::Length(0),
-            Constraint::Length(0),
-        ],
+        vec![Constraint::eq(0), Constraint::eq(0), Constraint::eq(0)],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
             "│                            │",
@@ -153,11 +145,7 @@ fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
 
     // columns of 1 width trim
     test_case(
-        &[
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ],
+        vec![Constraint::eq(1), Constraint::eq(1), Constraint::eq(1)],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
             "│H H H                       │",
@@ -174,11 +162,7 @@ fn widgets_table_columns_widths_can_use_fixed_length_constraints() {
 
     // columns of large width just before pushing a column off
     test_case(
-        &[
-            Constraint::Length(8),
-            Constraint::Length(8),
-            Constraint::Length(8),
-        ],
+        vec![Constraint::eq(8), Constraint::eq(8), Constraint::eq(8)],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
             "│Head1    Head2    Head3     │",
@@ -221,10 +205,10 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
 
     // columns of zero width show nothing
     test_case(
-        &[
-            Constraint::Percentage(0),
-            Constraint::Percentage(0),
-            Constraint::Percentage(0),
+        vec![
+            Constraint::eq(Unit::Percentage(0)),
+            Constraint::eq(Unit::Percentage(0)),
+            Constraint::eq(Unit::Percentage(0)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -242,10 +226,10 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
 
     // columns of not enough width trims the data
     test_case(
-        &[
-            Constraint::Percentage(11),
-            Constraint::Percentage(11),
-            Constraint::Percentage(11),
+        vec![
+            Constraint::eq(Unit::Percentage(11)),
+            Constraint::eq(Unit::Percentage(11)),
+            Constraint::eq(Unit::Percentage(11)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -263,10 +247,10 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
 
     // columns of large width just before pushing a column off
     test_case(
-        &[
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
+        vec![
+            Constraint::eq(Unit::Percentage(33)),
+            Constraint::eq(Unit::Percentage(33)),
+            Constraint::eq(Unit::Percentage(33)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -284,7 +268,10 @@ fn widgets_table_columns_widths_can_use_percentage_constraints() {
 
     // percentages summing to 100 should give equal widths
     test_case(
-        &[Constraint::Percentage(50), Constraint::Percentage(50)],
+        vec![
+            Constraint::eq(Unit::Percentage(50)),
+            Constraint::eq(Unit::Percentage(50)),
+        ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
             "│Head1         Head2         │",
@@ -326,10 +313,10 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
 
     // columns of zero width show nothing
     test_case(
-        &[
-            Constraint::Percentage(0),
-            Constraint::Length(0),
-            Constraint::Percentage(0),
+        vec![
+            Constraint::eq(Unit::Percentage(0)),
+            Constraint::eq(0),
+            Constraint::eq(Unit::Percentage(0)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -347,10 +334,10 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
 
     // columns of not enough width trims the data
     test_case(
-        &[
-            Constraint::Percentage(11),
-            Constraint::Length(20),
-            Constraint::Percentage(11),
+        vec![
+            Constraint::eq(Unit::Percentage(11)),
+            Constraint::eq(20),
+            Constraint::eq(Unit::Percentage(11)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -368,10 +355,10 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
 
     // columns of large width just before pushing a column off
     test_case(
-        &[
-            Constraint::Percentage(33),
-            Constraint::Length(10),
-            Constraint::Percentage(33),
+        vec![
+            Constraint::eq(Unit::Percentage(33)),
+            Constraint::eq(10),
+            Constraint::eq(Unit::Percentage(33)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -389,10 +376,10 @@ fn widgets_table_columns_widths_can_use_mixed_constraints() {
 
     // columns of large size (>100% total) hide the last column
     test_case(
-        &[
-            Constraint::Percentage(60),
-            Constraint::Length(10),
-            Constraint::Percentage(60),
+        vec![
+            Constraint::eq(Unit::Percentage(60)),
+            Constraint::eq(10),
+            Constraint::eq(Unit::Percentage(60)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -436,10 +423,10 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
 
     // columns of zero width show nothing
     test_case(
-        &[
-            Constraint::Ratio(0, 1),
-            Constraint::Ratio(0, 1),
-            Constraint::Ratio(0, 1),
+        vec![
+            Constraint::eq(Unit::Ratio(0, 1)),
+            Constraint::eq(Unit::Ratio(0, 1)),
+            Constraint::eq(Unit::Ratio(0, 1)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -457,10 +444,10 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
 
     // columns of not enough width trims the data
     test_case(
-        &[
-            Constraint::Ratio(1, 9),
-            Constraint::Ratio(1, 9),
-            Constraint::Ratio(1, 9),
+        vec![
+            Constraint::eq(Unit::Ratio(1, 9)),
+            Constraint::eq(Unit::Ratio(1, 9)),
+            Constraint::eq(Unit::Ratio(1, 9)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -478,10 +465,10 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
 
     // columns of large width just before pushing a column off
     test_case(
-        &[
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
+        vec![
+            Constraint::eq(Unit::Ratio(1, 3)),
+            Constraint::eq(Unit::Ratio(1, 3)),
+            Constraint::eq(Unit::Ratio(1, 3)),
         ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
@@ -499,7 +486,10 @@ fn widgets_table_columns_widths_can_use_ratio_constraints() {
 
     // percentages summing to 100 should give equal widths
     test_case(
-        &[Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)],
+        vec![
+            Constraint::eq(Unit::Ratio(1, 2)),
+            Constraint::eq(Unit::Ratio(1, 2)),
+        ],
         Buffer::with_lines(vec![
             "┌────────────────────────────┐",
             "│Head1         Head2         │",
@@ -532,11 +522,7 @@ fn widgets_table_can_have_rows_with_multi_lines() {
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
                 .block(Block::default().borders(Borders::ALL))
                 .highlight_symbol(">> ")
-                .widths(&[
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                ])
+                .widths([Constraint::eq(5), Constraint::eq(5), Constraint::eq(5)])
                 .column_spacing(1);
                 f.render_stateful_widget(table, size, state);
             })
@@ -635,11 +621,7 @@ fn widgets_table_can_have_elements_styled_individually() {
             .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
             .highlight_symbol(">> ")
             .highlight_style(Style::default().add_modifier(Modifier::BOLD))
-            .widths(&[
-                Constraint::Length(6),
-                Constraint::Length(6),
-                Constraint::Length(6),
-            ])
+            .widths([Constraint::eq(6), Constraint::eq(6), Constraint::eq(6)])
             .column_spacing(1);
             f.render_stateful_widget(table, size, &mut state);
         })
@@ -696,11 +678,7 @@ fn widgets_table_should_render_even_if_empty() {
             let table = Table::new(vec![])
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]))
                 .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-                .widths(&[
-                    Constraint::Length(6),
-                    Constraint::Length(6),
-                    Constraint::Length(6),
-                ])
+                .widths([Constraint::eq(6), Constraint::eq(6), Constraint::eq(6)])
                 .column_spacing(1);
             f.render_widget(table, size);
         })
@@ -736,11 +714,11 @@ fn widgets_table_columns_dont_panic() {
         .block(Block::default().borders(Borders::ALL))
         .highlight_symbol(">> ")
         .column_spacing(1)
-        .widths(&[
-            Constraint::Percentage(15),
-            Constraint::Percentage(15),
-            Constraint::Percentage(25),
-            Constraint::Percentage(45),
+        .widths([
+            Constraint::eq(Unit::Percentage(15)),
+            Constraint::eq(Unit::Percentage(15)),
+            Constraint::eq(Unit::Percentage(25)),
+            Constraint::eq(Unit::Percentage(45)),
         ]);
 
     let mut state = TableState::default();
@@ -771,11 +749,7 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
             ])
             .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
             .block(Block::default().borders(Borders::ALL))
-            .widths(&[
-                Constraint::Length(5),
-                Constraint::Length(5),
-                Constraint::Length(5),
-            ])
+            .widths([Constraint::eq(5), Constraint::eq(5), Constraint::eq(5)])
             .column_spacing(1);
             f.render_stateful_widget(table, size, &mut state);
         })
@@ -800,11 +774,7 @@ fn widgets_table_should_clamp_offset_if_rows_are_removed() {
             let table = Table::new(vec![Row::new(vec!["Row31", "Row32", "Row33"])])
                 .header(Row::new(vec!["Head1", "Head2", "Head3"]).bottom_margin(1))
                 .block(Block::default().borders(Borders::ALL))
-                .widths(&[
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                    Constraint::Length(5),
-                ])
+                .widths([Constraint::eq(5), Constraint::eq(5), Constraint::eq(5)])
                 .column_spacing(1);
             f.render_stateful_widget(table, size, &mut state);
         })


### PR DESCRIPTION
## Description

`Layout` allows users to split a given `Rect` in multiple chunks according to list of `Constraints`. It has several shortcomings:
- it allows a single constraints by chunk.
- all constraints have the same weight so the underlying layout solver has to pick randomly which rule to break.
- there is no way to tell to `tui` to have one chunk fill the remaining space — it only works in some cases because internally constraints are added to link the last chunk border and the edge of the area.

This PR proposes 2 changes:
- to allow multiple constraints by chunk.
- to let users weight their constraints in order to control the order in which constraints get broken.

For example, let's say you have a table with 3 colums and you want the following behavior:
- width of the first column should always be 10
- width of the second column should be 20
- the third column should fill the rest of the space
- if the total width is reduced, the third columns shrinks until 20, then the second column until 10, then the third to 0, then the second to 0 and finally the first one to 0.

This can expressed as the following with the new changes — the higher the weight the stronger the constraint:
```rust
Table::new()
  .widths([
    // first column
    Constraint::eq(10).weight(50),
    // second column
    Constraints::from_iter([
      Constraint::gte(10).weight(40),
      Constraint::eq(20).weight(20)
    ]),
    // third column
    Constraint::from_iter([
      Constraint::gte(20).weight(30),
      Constraint::eq(Unit::Percentage(100)).weight(10),
    ])
  ]);
```

Known limitations: because we don't have a way to size based on content `Constraint::gte(0)` alone produces a zero width result which might not be expected from people used to more traditional layout system.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

## Checklist

* [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ ] I have added relevant tests.
* [ ] I have documented all new additions.
