### PR TITLE
List repeat highlight symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## To be released
+### Features
+* Add option to `widgets::List` to repeat the hightlight symbol for each line of multi-line items.
 
 ## v0.16.0 - 2021-08-01
 

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -126,3 +126,72 @@ fn widgets_list_should_clamp_offset_if_items_are_removed() {
     let expected = Buffer::with_lines(vec!["   Item 3 ", "          ", "          ", "          "]);
     terminal.backend().assert_buffer(&expected);
 }
+
+#[test]
+fn widgets_list_should_display_multiline_items() {
+    let backend = TestBackend::new(10, 6);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut state = ListState::default();
+    state.select(Some(1));
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let items = vec![
+                ListItem::new(vec![Spans::from("Item 1"), Spans::from("Item 1a")]),
+                ListItem::new(vec![Spans::from("Item 2"), Spans::from("Item 2b")]),
+                ListItem::new(vec![Spans::from("Item 3"), Spans::from("Item 3c")]),
+            ];
+            let list = List::new(items)
+                .highlight_style(Style::default().bg(Color::Yellow))
+                .highlight_symbol(">> ");
+            f.render_stateful_widget(list, size, &mut state);
+        })
+        .unwrap();
+    let mut expected = Buffer::with_lines(vec![
+        "   Item 1 ",
+        "   Item 1a",
+        ">> Item 2 ",
+        "   Item 2b",
+        "   Item 3 ",
+        "   Item 3c"]);
+    for x in 0..10 {
+        expected.get_mut(x, 2).set_bg(Color::Yellow);
+        expected.get_mut(x, 3).set_bg(Color::Yellow);
+    }
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_list_should_repeat_highlight_symbol() {
+    let backend = TestBackend::new(10, 6);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut state = ListState::default();
+    state.select(Some(1));
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let items = vec![
+                ListItem::new(vec![Spans::from("Item 1"), Spans::from("Item 1a")]),
+                ListItem::new(vec![Spans::from("Item 2"), Spans::from("Item 2b")]),
+                ListItem::new(vec![Spans::from("Item 3"), Spans::from("Item 3c")]),
+            ];
+            let list = List::new(items)
+                .highlight_style(Style::default().bg(Color::Yellow))
+                .highlight_symbol(">> ")
+                .repeat_highlight_symbol(true);
+            f.render_stateful_widget(list, size, &mut state);
+        })
+        .unwrap();
+    let mut expected = Buffer::with_lines(vec![
+        "   Item 1 ",
+        "   Item 1a",
+        ">> Item 2 ",
+        ">> Item 2b",
+        "   Item 3 ",
+        "   Item 3c"]);
+    for x in 0..10 {
+        expected.get_mut(x, 2).set_bg(Color::Yellow);
+        expected.get_mut(x, 3).set_bg(Color::Yellow);
+    }
+    terminal.backend().assert_buffer(&expected);
+}


### PR DESCRIPTION
## Description
Adds an option to `List` to enable repeating the highlight symbol on every line of the selected item (in the case of multi-line items). This allows one to use for instance `tui::symbols::line::VERTICAL` as the highlight symbol. E.g: 
![image](https://user-images.githubusercontent.com/506344/133011988-715a4f47-0265-4797-9a15-084f65691d44.png)

closes: #532 

## Testing guidelines
A couple of new tests were added.

## Checklist

* [ x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ x] I have added relevant tests.
* [ x] I have documented all new additions.
