### PR TITLE
Bump the minimum supported Rust version to 1.46

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.44.0", "stable"]
+        rust: ["1.46.0", "stable"]
     steps:
       - name: "Install dependencies"
         run: sudo apt-get install libncurses5-dev
@@ -53,7 +53,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        rust: ["1.44.0", "stable"]
+        rust: ["1.46.0", "stable"]
     steps:
       - uses: actions/checkout@v1
       - uses: hecrj/setup-rust-action@967aec96c6a27a0ce15c1dac3aaba332d60565e2


### PR DESCRIPTION
## Description

It looks like the `bitflags` crate now requires at least Rust 1.46 due to some `const fn` usage, so this bumps the minimum supported Rust version in the github actions config accordingly. This should fix the failing tests in PRs.

## Testing guidelines
n/a

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
