### PR TITLE
chore: pin `bitflags` version to 1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["termion"]
 curses = ["easycurses", "pancurses"]
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.3"
 cassowary = "0.3"
 unicode-segmentation = "1.2"
 unicode-width = "0.1"


### PR DESCRIPTION
## Description

Restrict minor version of `bitflags` to avoid breaking changes like https://github.com/fdehau/tui-rs/pull/534

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
