### PR TITLE
feat!(widgets/canvas): use spans for text of labels

### DIFF
--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -7,7 +7,8 @@ use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::Altern
 use tui::{
     backend::TermionBackend,
     layout::{Constraint, Direction, Layout, Rect},
-    style::Color,
+    style::{Color, Style},
+    text::Span,
     widgets::{
         canvas::{Canvas, Map, MapResolution, Rectangle},
         Block, Borders,
@@ -103,7 +104,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                         color: Color::White,
                         resolution: MapResolution::High,
                     });
-                    ctx.print(app.x, -app.y, "You are here", Color::Yellow);
+                    ctx.print(
+                        app.x,
+                        -app.y,
+                        Span::styled("You are here", Style::default().fg(Color::Yellow)),
+                    );
                 })
                 .x_bounds([-180.0, 180.0])
                 .y_bounds([-90.0, 90.0]);

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -363,7 +363,11 @@ where
                 } else {
                     Color::Red
                 };
-                ctx.print(server.coords.1, server.coords.0, "X", color);
+                ctx.print(
+                    server.coords.1,
+                    server.coords.0,
+                    Span::styled("X", Style::default().fg(color)),
+                );
             }
         })
         .marker(if app.enhanced_graphics {

--- a/tests/widgets_canvas.rs
+++ b/tests/widgets_canvas.rs
@@ -1,0 +1,42 @@
+use tui::{
+    backend::TestBackend,
+    buffer::Buffer,
+    style::{Color, Style},
+    text::Span,
+    widgets::canvas::Canvas,
+    Terminal,
+};
+
+#[test]
+fn widgets_canvas_draw_labels() {
+    let backend = TestBackend::new(5, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            let label = String::from("test");
+            let canvas = Canvas::default()
+                .background_color(Color::Yellow)
+                .x_bounds([0.0, 5.0])
+                .y_bounds([0.0, 5.0])
+                .paint(|ctx| {
+                    ctx.print(
+                        0.0,
+                        0.0,
+                        Span::styled(label.clone(), Style::default().fg(Color::Blue)),
+                    );
+                });
+            f.render_widget(canvas, f.size());
+        })
+        .unwrap();
+
+    let mut expected = Buffer::with_lines(vec!["    ", "    ", "     ", "     ", "test "]);
+    for row in 0..5 {
+        for col in 0..5 {
+            expected.get_mut(col, row).set_bg(Color::Yellow);
+        }
+    }
+    for col in 0..4 {
+        expected.get_mut(col, 4).set_fg(Color::Blue);
+    }
+    terminal.backend().assert_buffer(&expected)
+}


### PR DESCRIPTION
## Description

Change `canvas::Context::print` to use `Spans` rather than `&str` and `Color` so labels can have complex style and label content can be owned content.

Fixes #529 

## Testing guidelines

```
cargo test widgets_canvas
cargo run --example canvas
```

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
