### PR TITLE
Feature: Block padding

### DIFF
--- a/examples/block.rs
+++ b/examples/block.rs
@@ -9,7 +9,7 @@ use tui::{
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     text::Span,
-    widgets::{Block, BorderType, Borders},
+    widgets::{Block, BorderType, Borders, Paragraph},
     Terminal,
 };
 
@@ -79,16 +79,30 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .split(chunks[1]);
 
             // Bottom left block with all default borders
-            let block = Block::default().title("With borders").borders(Borders::ALL);
-            f.render_widget(block, bottom_chunks[0]);
+            let block = Block::default()
+                .title("With borders")
+                .borders(Borders::ALL)
+                .vertical_padding(2)
+                .horizontal_padding(4);
+
+            let text = Paragraph::new("text inside padded block").block(block);
+            f.render_widget(text, bottom_chunks[0]);
 
             // Bottom right block with styled left and right border
             let block = Block::default()
                 .title("With styled borders and doubled borders")
                 .border_style(Style::default().fg(Color::Cyan))
                 .borders(Borders::LEFT | Borders::RIGHT)
-                .border_type(BorderType::Double);
+                .border_type(BorderType::Double)
+                .padding(1);
+
+            let inner_block = Block::default()
+                .title("Block inside padded block")
+                .borders(Borders::ALL);
+
+            let inner_area = block.inner(bottom_chunks[1]);
             f.render_widget(block, bottom_chunks[1]);
+            f.render_widget(inner_block, inner_area);
         })?;
 
         if let Event::Input(key) = events.next()? {

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -26,6 +26,21 @@ impl BorderType {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Padding {
+    pub vertical: u16,
+    pub horizontal: u16,
+}
+
+impl Padding {
+    pub fn zero() -> Padding {
+        Padding {
+            horizontal: 0,
+            vertical: 0
+        }
+    }
+}
+
 /// Base widget to be used with all upper level ones. It may be used to display a box border around
 /// the widget and/or add a title.
 ///
@@ -57,6 +72,8 @@ pub struct Block<'a> {
     border_type: BorderType,
     /// Widget style
     style: Style,
+    /// Block padding
+    padding: Padding,
 }
 
 impl<'a> Default for Block<'a> {
@@ -68,6 +85,7 @@ impl<'a> Default for Block<'a> {
             border_style: Default::default(),
             border_type: BorderType::Plain,
             style: Default::default(),
+            padding: Padding::zero()
         }
     }
 }
@@ -135,7 +153,32 @@ impl<'a> Block<'a> {
         if self.borders.intersects(Borders::BOTTOM) {
             inner.height = inner.height.saturating_sub(1);
         }
+
+        inner.x = inner.x.saturating_add(self.padding.horizontal);
+        inner.y = inner.y.saturating_add(self.padding.vertical);
+
+        inner.width = inner.width.saturating_sub(self.padding.horizontal * 2);
+        inner.height = inner.height.saturating_sub(self.padding.vertical * 2);
+
         inner
+    }
+
+    pub fn padding(mut self, padding: u16) -> Block<'a> {
+        self.padding = Padding {
+            horizontal: padding,
+            vertical: padding,
+        };
+        self
+    }
+
+    pub fn horizontal_padding(mut self, horizontal: u16) -> Block<'a> {
+        self.padding.horizontal = horizontal;
+        self
+    }
+
+    pub fn vertical_padding(mut self, vertical: u16) -> Block<'a> {
+        self.padding.vertical = vertical;
+        self
     }
 }
 

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -36,7 +36,7 @@ impl Padding {
     pub fn zero() -> Padding {
         Padding {
             horizontal: 0,
-            vertical: 0
+            vertical: 0,
         }
     }
 }
@@ -85,7 +85,7 @@ impl<'a> Default for Block<'a> {
             border_style: Default::default(),
             border_type: BorderType::Plain,
             style: Default::default(),
-            padding: Padding::zero()
+            padding: Padding::zero(),
         }
     }
 }

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -15,7 +15,7 @@ const SAMPLE_STRING: &str = "The library is based on the principle of immediate 
 #[test]
 fn widgets_paragraph_can_wrap_its_content() {
     let test_case = |alignment, expected| {
-        let backend = TestBackend::new(20, 10);
+        let backend = TestBackend::new(22, 12);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
@@ -23,7 +23,7 @@ fn widgets_paragraph_can_wrap_its_content() {
                 let size = f.size();
                 let text = vec![Spans::from(SAMPLE_STRING)];
                 let paragraph = Paragraph::new(text)
-                    .block(Block::default().borders(Borders::ALL))
+                    .block(Block::default().borders(Borders::ALL).padding(1))
                     .alignment(alignment)
                     .wrap(Wrap { trim: true });
                 f.render_widget(paragraph, size);
@@ -35,46 +35,52 @@ fn widgets_paragraph_can_wrap_its_content() {
     test_case(
         Alignment::Left,
         Buffer::with_lines(vec![
-            "┌──────────────────┐",
-            "│The library is    │",
-            "│based on the      │",
-            "│principle of      │",
-            "│immediate         │",
-            "│rendering with    │",
-            "│intermediate      │",
-            "│buffers. This     │",
-            "│means that at each│",
-            "└──────────────────┘",
+            "┌────────────────────┐",
+            "│                    │",
+            "│ The library is     │",
+            "│ based on the       │",
+            "│ principle of       │",
+            "│ immediate          │",
+            "│ rendering with     │",
+            "│ intermediate       │",
+            "│ buffers. This      │",
+            "│ means that at each │",
+            "│                    │",
+            "└────────────────────┘",
         ]),
     );
     test_case(
         Alignment::Right,
         Buffer::with_lines(vec![
-            "┌──────────────────┐",
-            "│    The library is│",
-            "│      based on the│",
-            "│      principle of│",
-            "│         immediate│",
-            "│    rendering with│",
-            "│      intermediate│",
-            "│     buffers. This│",
-            "│means that at each│",
-            "└──────────────────┘",
+            "┌────────────────────┐",
+            "│                    │",
+            "│     The library is │",
+            "│       based on the │",
+            "│       principle of │",
+            "│          immediate │",
+            "│     rendering with │",
+            "│       intermediate │",
+            "│      buffers. This │",
+            "│ means that at each │",
+            "│                    │",
+            "└────────────────────┘",
         ]),
     );
     test_case(
         Alignment::Center,
         Buffer::with_lines(vec![
-            "┌──────────────────┐",
-            "│  The library is  │",
-            "│   based on the   │",
-            "│   principle of   │",
-            "│     immediate    │",
-            "│  rendering with  │",
-            "│   intermediate   │",
-            "│   buffers. This  │",
-            "│means that at each│",
-            "└──────────────────┘",
+            "┌────────────────────┐",
+            "│                    │",
+            "│   The library is   │",
+            "│    based on the    │",
+            "│    principle of    │",
+            "│      immediate     │",
+            "│   rendering with   │",
+            "│    intermediate    │",
+            "│    buffers. This   │",
+            "│ means that at each │",
+            "│                    │",
+            "└────────────────────┘",
         ]),
     );
 }


### PR DESCRIPTION
## Description
If we want to render a widget inside a block with a certain distance from its borders, we need to create another `Layout` element based on the outer `Block`, add a margin and render the Widget into it. Adding a padding property on the block element skips the creation of this second Layout.

This property works especially when rendering texts, as we can just create a block with padding and use it as the text wrapper:

```rust
let block = Block::default().borders(Borders::ALL).padding(4);
let paragraph = Paragraph::new("example paragraph").block(block);
f.render_widget(paragraph, area);
```

Rendering another widget should be easy too, using the `.inner` method:

```rust
let block = Block::default().borders(Borders::ALL).padding(4);
let inner_block = Block::default().borders(Borders::ALL);
let inner_area = block.inner(area);

f.render_widget(block, area);
f.render_widget(inner_block, inner_area);
```

## Testing guidelines
The `block.rs` example contains two cases of use: one with an inner text and another with an inner block:
![image](https://user-images.githubusercontent.com/19190744/139556222-d474aa9f-a3f0-4f78-bab5-c93d4ea4d264.png)

I've also changed the paragraph tests to include a padding of value 1 to the rendering tests.

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [X] I have added relevant tests.
* [X] I have documented all new additions.
