### PR TITLE
chore: fix table example

### DIFF
--- a/examples/table.rs
+++ b/examples/table.rs
@@ -149,7 +149,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         .widths(&[
             Constraint::Percentage(50),
             Constraint::Length(30),
-            Constraint::Max(10),
+            Constraint::Min(10),
         ]);
     f.render_stateful_widget(t, rects[0], &mut app.state);
 }


### PR DESCRIPTION
## Description

Third column in table example was using the `Max` constraint.

But since version 0.16, the layout system does not add a hidden constraint on the last column which would ensure that it fills the remaining available space (a change that was already mentioned in #525). In addition, `tui` does not support sizing based on content because of its immediate mode nature. Therefore, `Max` is now resolved to `0`. Replacing with `Min` fixes the issue.

A new way of specifying constraints is being worked on at #519 which should for more deterministic and advanced layout.

Fixes #561 

## Testing guidelines

```
cargo run --example table
```

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
