### PR TITLE
Chart axis alignment

### DIFF
--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -412,36 +412,34 @@ impl<'a> Chart<'a> {
 
         let width_between_ticks = graph_area.width / labels_len;
 
-        for (i, label) in labels.iter().enumerate() {
-            if i == 0 {
-                let label_area = self.first_x_label_area(
-                    y,
-                    label.width() as u16,
-                    width_between_ticks,
-                    chart_area,
-                    graph_area,
-                );
+        let label_area = self.first_x_label_area(
+            y,
+            labels.first().unwrap().width() as u16,
+            width_between_ticks,
+            chart_area,
+            graph_area,
+        );
 
-                let alignment = match self.x_axis.labels_alignment {
-                    Alignment::Left => Alignment::Right,
-                    Alignment::Center => Alignment::Center,
-                    Alignment::Right => Alignment::Left,
-                };
+        let label_alignment = match self.x_axis.labels_alignment {
+            Alignment::Left => Alignment::Right,
+            Alignment::Center => Alignment::Center,
+            Alignment::Right => Alignment::Left,
+        };
 
-                Self::render_label(buf, label, label_area, alignment);
-            } else if i == labels.len() - 1 {
-                let x = graph_area.right() - width_between_ticks;
-                let label_area = Rect::new(x, y, width_between_ticks, 1);
-                // The last label should be aligned Right to be at the edge of the graph area
-                Self::render_label(buf, label, label_area, Alignment::Right);
-            } else {
-                // We do a +1 (and width-1 below) to leave at least one space before each intermediate labels
-                let x = graph_area.left() + i as u16 * width_between_ticks + 1;
-                let label_area = Rect::new(x, y, width_between_ticks.saturating_sub(1), 1);
+        Self::render_label(buf, labels.first().unwrap(), label_area, label_alignment);
 
-                Self::render_label(buf, label, label_area, Alignment::Center);
-            }
+        for (i, label) in labels[1..labels.len() - 1].iter().enumerate() {
+            // We add 1 to x (and width-1 below) to leave at least one space before each intermediate labels
+            let x = graph_area.left() + (i + 1) as u16 * width_between_ticks + 1;
+            let label_area = Rect::new(x, y, width_between_ticks.saturating_sub(1), 1);
+
+            Self::render_label(buf, label, label_area, Alignment::Center);
         }
+
+        let x = graph_area.right() - width_between_ticks;
+        let label_area = Rect::new(x, y, width_between_ticks, 1);
+        // The last label should be aligned Right to be at the edge of the graph area
+        Self::render_label(buf, labels.last().unwrap(), label_area, Alignment::Right);
     }
 
     fn first_x_label_area(

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -378,6 +378,7 @@ impl<'a> Chart<'a> {
                 let mut first_label_width = x_labels[0].content.width() as u16;
                 first_label_width = match self.x_axis.label_alignment {
                     Alignment::Left => {
+                        // The last character of the label should be below the Y-Axis when it exists, not on its left
                         let y_axis_offset = if has_y_axis { 1 } else { 0 };
                         first_label_width.saturating_sub(y_axis_offset)
                     }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -413,8 +413,13 @@ impl<'a> Chart<'a> {
 
         for (i, label) in labels.iter().enumerate() {
             if i == 0 {
-                let label_area =
-                    self.first_x_label_area(y, width_between_ticks, chart_area, graph_area);
+                let label_area = self.first_x_label_area(
+                    y,
+                    label.width() as u16,
+                    width_between_ticks,
+                    chart_area,
+                    graph_area,
+                );
 
                 let alignment = match self.x_axis.label_alignment {
                     Alignment::Left => Alignment::Right,
@@ -441,6 +446,7 @@ impl<'a> Chart<'a> {
     fn first_x_label_area(
         &self,
         y: u16,
+        label_width: u16,
         max_width_after_y_axis: u16,
         chart_area: Rect,
         graph_area: Rect,
@@ -449,7 +455,7 @@ impl<'a> Chart<'a> {
             Alignment::Left => (chart_area.left(), graph_area.left()),
             Alignment::Center => (
                 chart_area.left(),
-                graph_area.left() + max_width_after_y_axis,
+                graph_area.left() + max_width_after_y_axis.min(label_width),
             ),
             Alignment::Right => (
                 graph_area.left().saturating_sub(1),

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -25,7 +25,7 @@ pub struct Axis<'a> {
     /// The style used to draw the axis itself
     style: Style,
     /// The alignment of the labels of the Axis
-    label_alignment: Alignment,
+    labels_alignment: Alignment,
 }
 
 impl<'a> Default for Axis<'a> {
@@ -35,7 +35,7 @@ impl<'a> Default for Axis<'a> {
             bounds: [0.0, 0.0],
             labels: None,
             style: Default::default(),
-            label_alignment: Alignment::Left,
+            labels_alignment: Alignment::Left,
         }
     }
 }
@@ -80,8 +80,8 @@ impl<'a> Axis<'a> {
     /// The alignment behaves differently based on the axis:
     /// - Y-Axis: The labels are aligned within the area on the left of the axis
     /// - X-Axis: The first X-axis label is aligned relative to the Y-axis
-    pub fn label_alignment(mut self, alignment: Alignment) -> Axis<'a> {
-        self.label_alignment = alignment;
+    pub fn labels_alignment(mut self, alignment: Alignment) -> Axis<'a> {
+        self.labels_alignment = alignment;
         self
     }
 }
@@ -376,7 +376,7 @@ impl<'a> Chart<'a> {
         if let Some(ref x_labels) = self.x_axis.labels {
             if !x_labels.is_empty() {
                 let first_label_width = x_labels[0].content.width() as u16;
-                let width_left_of_y_axis = match self.x_axis.label_alignment {
+                let width_left_of_y_axis = match self.x_axis.labels_alignment {
                     Alignment::Left => {
                         // The last character of the label should be below the Y-Axis when it exists, not on its left
                         let y_axis_offset = if has_y_axis { 1 } else { 0 };
@@ -421,7 +421,7 @@ impl<'a> Chart<'a> {
                     graph_area,
                 );
 
-                let alignment = match self.x_axis.label_alignment {
+                let alignment = match self.x_axis.labels_alignment {
                     Alignment::Left => Alignment::Right,
                     Alignment::Center => Alignment::Center,
                     Alignment::Right => Alignment::Left,
@@ -451,7 +451,7 @@ impl<'a> Chart<'a> {
         chart_area: Rect,
         graph_area: Rect,
     ) -> Rect {
-        let (min_x, max_x) = match self.x_axis.label_alignment {
+        let (min_x, max_x) = match self.x_axis.labels_alignment {
             Alignment::Left => (chart_area.left(), graph_area.left()),
             Alignment::Center => (
                 chart_area.left(),
@@ -501,7 +501,7 @@ impl<'a> Chart<'a> {
                     (graph_area.left() - chart_area.left()).saturating_sub(1),
                     1,
                 );
-                Self::render_label(buf, label, label_area, self.y_axis.label_alignment);
+                Self::render_label(buf, label, label_area, self.y_axis.labels_alignment);
             }
         }
     }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -375,8 +375,8 @@ impl<'a> Chart<'a> {
             .unwrap_or_default();
         if let Some(ref x_labels) = self.x_axis.labels {
             if !x_labels.is_empty() {
-                let mut first_label_width = x_labels[0].content.width() as u16;
-                first_label_width = match self.x_axis.label_alignment {
+                let first_label_width = x_labels[0].content.width() as u16;
+                let width_left_of_y_axis = match self.x_axis.label_alignment {
                     Alignment::Left => {
                         // The last character of the label should be below the Y-Axis when it exists, not on its left
                         let y_axis_offset = if has_y_axis { 1 } else { 0 };
@@ -385,7 +385,7 @@ impl<'a> Chart<'a> {
                     Alignment::Center => first_label_width / 2,
                     Alignment::Right => 0,
                 };
-                max_width = max(max_width, first_label_width);
+                max_width = max(max_width, width_left_of_y_axis);
             }
         }
         // labels of y axis and first label of x axis can take at most 1/3rd of the total width
@@ -429,7 +429,7 @@ impl<'a> Chart<'a> {
                 // The last label should be aligned Right to be at the edge of the graph area
                 Self::render_label(buf, label, label_area, Alignment::Right);
             } else {
-                // We do a +1 (and width-1 below) to leave at least one space before intermediate labels
+                // We do a +1 (and width-1 below) to leave at least one space before each intermediate labels
                 let x = graph_area.left() + i as u16 * width_between_ticks + 1;
                 let label_area = Rect::new(x, y, width_between_ticks.saturating_sub(1), 1);
 

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -434,13 +434,22 @@ impl<'a> Chart<'a> {
         }
     }
 
-    fn first_x_label_area(&self, y: u16, width: u16, chart_area: Rect, graph_area: Rect) -> Rect {
+    fn first_x_label_area(
+        &self,
+        y: u16,
+        max_width_after_y_axis: u16,
+        chart_area: Rect,
+        graph_area: Rect,
+    ) -> Rect {
         let (min_x, max_x) = match self.x_axis.label_alignment {
             Alignment::Left => (chart_area.left(), graph_area.left()),
-            Alignment::Center => (chart_area.left(), graph_area.left() + width),
+            Alignment::Center => (
+                chart_area.left(),
+                graph_area.left() + max_width_after_y_axis,
+            ),
             Alignment::Right => (
                 graph_area.left().saturating_sub(1),
-                graph_area.left() + width,
+                graph_area.left() + max_width_after_y_axis,
             ),
         };
 

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -497,8 +497,8 @@ impl<'a> Chart<'a> {
             if dy < graph_area.bottom() {
                 let label_area = Rect::new(
                     x,
-                    graph_area.bottom() - 1 - dy,
-                    graph_area.left() - chart_area.left() - 1,
+                    graph_area.bottom().saturating_sub(1) - dy,
+                    (graph_area.left() - chart_area.left()).saturating_sub(1),
                     1,
                 );
                 Self::render_label(buf, label, label_area, self.y_axis.label_alignment);

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -71,7 +71,7 @@ fn widgets_chart_handles_long_labels() {
         if let Some((left_label, right_label)) = x_labels {
             x_axis = x_axis
                 .labels(vec![Span::from(left_label), Span::from(right_label)])
-                .label_alignment(x_alignment);
+                .labels_alignment(x_alignment);
         }
 
         let mut y_axis = Axis::default().bounds([0.0, 1.0]);
@@ -173,7 +173,7 @@ fn widgets_chart_handles_x_axis_labels_alignments() {
     let test_case = |y_alignment, lines| {
         let x_axis = Axis::default()
             .labels(vec![Span::from("AAAA"), Span::from("B"), Span::from("C")])
-            .label_alignment(y_alignment);
+            .labels_alignment(y_alignment);
 
         let y_axis = Axis::default();
 
@@ -219,7 +219,7 @@ fn widgets_chart_handles_y_axis_labels_alignments() {
 
         let y_axis = Axis::default()
             .labels(create_labels(&["C", "D"]))
-            .label_alignment(y_alignment);
+            .labels_alignment(y_alignment);
 
         axis_test_case(20, 5, x_axis, y_axis, lines);
     };

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -169,16 +169,13 @@ fn widgets_chart_handles_x_axis_labels_alignments() {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|f| {
-                let datasets = vec![Dataset::default()
-                    .marker(symbols::Marker::Braille)
-                    .style(Style::default().fg(Color::Magenta))
-                    .data(&[(2.0, 2.0)])];
                 let x_axis = Axis::default()
-                    .bounds([0.0, 1.0])
                     .labels(vec![Span::from("AAAA"), Span::from("B"), Span::from("C")])
                     .label_alignment(alignment);
-                let y_axis = Axis::default().bounds([0.0, 1.0]);
-                let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+
+                let y_axis = Axis::default();
+
+                let chart = Chart::new(vec![]).x_axis(x_axis).y_axis(y_axis);
                 f.render_widget(chart, f.size());
             })
             .unwrap();
@@ -213,6 +210,58 @@ fn widgets_chart_handles_x_axis_labels_alignments() {
             "          ",
             "──────────",
             "AAA  B   C",
+        ],
+    );
+}
+
+#[test]
+fn widgets_chart_handles_y_axis_labels_alignments() {
+    let test_case = |y_alignment, lines| {
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let x_axis = Axis::default().labels(create_labels(&["AAAAA", "B"]));
+
+                let y_axis = Axis::default()
+                    .labels(create_labels(&["C", "D"]))
+                    .label_alignment(y_alignment);
+
+                let chart = Chart::new(vec![]).x_axis(x_axis).y_axis(y_axis);
+                f.render_widget(chart, f.size());
+            })
+            .unwrap();
+        let expected = Buffer::with_lines(lines);
+        terminal.backend().assert_buffer(&expected);
+    };
+    test_case(
+        Alignment::Left,
+        vec![
+            "D   │               ",
+            "    │               ",
+            "C   │               ",
+            "    └───────────────",
+            "AAAAA              B",
+        ],
+    );
+    test_case(
+        Alignment::Center,
+        vec![
+            "  D │               ",
+            "    │               ",
+            "  C │               ",
+            "    └───────────────",
+            "AAAAA              B",
+        ],
+    );
+    test_case(
+        Alignment::Right,
+        vec![
+            "   D│               ",
+            "    │               ",
+            "   C│               ",
+            "    └───────────────",
+            "AAAAA              B",
         ],
     );
 }


### PR DESCRIPTION
## Description

This PR allows users to customize the alignment of the chart widget's axis' labels.
It implements a solution of the issue #567.

The alignment can be customized through the new method `Axis::labels_alignment(alignment: Alignment)`:

```rust
let axis = Axis::default()
    .labels([Span::from("0"), Span::from("100")])
    .labels_alignment(Alignment::Right);
```

By default, the alignment of an `Axis` is `Alignment::Left`.
This produces an output similar to the one currently produced.

Defining the alignment of the Y axis will affect the position of all Y-axis labels.
Defining the alignment of the X axis will only affect the position of the first label, relative to the Y-axis.

A side-effect of the PR is that X-axis labels are now closer to their correct position.
Currently on the  branch `master`:
![image](https://user-images.githubusercontent.com/16946214/145281066-0bb69b7b-41d9-4c6c-bbbf-bd960892ad81.png)
With this PR:
![image](https://user-images.githubusercontent.com/16946214/145281268-28a1821d-25c5-4555-93cf-508a5f5c3baa.png)


## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->
New scenarios have been added in `tests/widgets_chart.rs` to test the output produced by different alignments.

### X-Axis label alignments:
`Alignment::Left` (*default*)
![image](https://user-images.githubusercontent.com/16946214/145281574-35c113de-9d5c-4477-aa3f-80b072b30b4c.png)
`Alignment::Center`
![image](https://user-images.githubusercontent.com/16946214/145281616-5cdf6db4-1fe3-4316-ad79-44615fd505f4.png)
`Alignment::Right`
![image](https://user-images.githubusercontent.com/16946214/145281677-f5b4918f-734e-4e1e-b3dd-4f2ce6d2cc76.png)

### Y-Axis label alignments:
`Alignment::Left` (*default*)
![image](https://user-images.githubusercontent.com/16946214/145281846-b60ddbaf-df44-440b-bc5c-e771c9f49890.png)
`Alignment::Center`
![image](https://user-images.githubusercontent.com/16946214/145281979-bc2e484e-7899-4cc4-86b6-fc54af2252b5.png)
`Alignment::Right`
![image](https://user-images.githubusercontent.com/16946214/145282023-f9333ccb-db8f-43e3-b557-7d7ca180b5df.png)

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
