### PR TITLE
update. Add `hwatch` to list of projects using.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The library comes with the following list of widgets:
   * [Canvas (with line, point cloud, map)](https://github.com/fdehau/tui-rs/blob/v0.17.0/examples/canvas.rs)
   * [Tabs](https://github.com/fdehau/tui-rs/blob/v0.17.0/examples/tabs.rs)
 
-Click on each item to see the source of the example. Run the examples with with 
+Click on each item to see the source of the example. Run the examples with with
 cargo (e.g. to run the gauge example `cargo run --example gauge`), and quit by pressing `q`.
 
 You can run all examples by running `cargo make run-examples` (require
@@ -108,6 +108,7 @@ You can run all examples by running `cargo make run-examples` (require
 * [joshuto](https://github.com/kamiyaa/joshuto)
 * [adsb_deku/radar](https://github.com/wcampbell0x2a/adsb_deku#radar-tui)
 * [hoard](https://github.com/Hyde46/hoard)
+* [hwatch](https://github.com/blacknon/hwatch)
 
 ### Alternatives
 


### PR DESCRIPTION
## Description

Add [hwatch](https://github.com/blacknon/hwatch) to list of projects using `tui`

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
