### PR TITLE
Add ytui-music to list of app using tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can run all examples by running `cargo make run-examples` (require
 * [joshuto](https://github.com/kamiyaa/joshuto)
 * [adsb_deku/radar](https://github.com/wcampbell0x2a/adsb_deku#radar-tui)
 * [hoard](https://github.com/Hyde46/hoard)
+* [ytui-music] (https://github.com/sudipghimire533/ytui-music)
 
 ### Alternatives
 


### PR DESCRIPTION
## Description
Add [`ytui-music`](https://github.com/sudipghimire533/ytui-music) project to the list of "apps using tui"

This is a project created by me, few months ago and I have decided to continue working on it again. I was inspired from [spotify-yui](https://github.com/Rigellute/spotify-tui) and this projects to achive similar things as spotify-tui does.

It is a youtube client in terminal with tui ( ofcourse everyone loves tui ) that is intended to be private, easy and configurable. So being enlisted in this list would be great honour.

This would also be use for many of us those who are ATTACHED to music and to terminal. I kept in mind that non everyone who loves terminal need not to be IT geek ( take my childhood for example :wink: ). So it comes with decent default configuration and obvious usage behaviour.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
