### PR TITLE
Update crossterm to v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cassowary = "0.3"
 unicode-segmentation = "1.2"
 unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
-crossterm = { version = "0.22", optional = true }
+crossterm = { version = "0.23", optional = true }
 serde = { version = "1", optional = true, features = ["derive"]}
 
 [dev-dependencies]


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->

Updates `crossterm` to the latest version, see [`crossterm`'s changelog](https://github.com/crossterm-rs/crossterm/blob/master/CHANGELOG.md#version-023). (Personally, I'm just wanted to get rid of an outdated dependency warning in one of my projects lol.)

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

Builds, no clippy lints

`cargo make ci` fails, but this also happens without `crossterm` being updated (below is run on `master`):
```
error: single-character string constant used as pattern
   --> src\widgets\reflow.rs:492:39
    |
492 |         let text_space = text.replace("\u{00a0}", " ");
    |                                       ^^^^^^^^^^ help: try using a `char` instead: `'\u{00a0}'`
    |
    = note: `-D clippy::single-char-pattern` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern
```

`cargo test` passes

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
