### PR TITLE
feat(widgets/chart): add option to set the position of legend

### DIFF
--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use tui::{
     backend::{Backend, CrosstermBackend},
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Corner, Direction, Layout},
     style::{Color, Modifier, Style},
     symbols,
     text::Span,
@@ -296,6 +296,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
                     Span::raw("2.5"),
                     Span::styled("5", Style::default().add_modifier(Modifier::BOLD)),
                 ]),
-        );
+        )
+        .legend_position(Corner::BottomRight);
     f.render_widget(chart, chunks[2]);
 }


### PR DESCRIPTION
## Description

<!--
A clear and concise description of what this PR changes.
-->

Add option to position the legend at corner. The option uses `tui::layout::Corner` emum that already made.

If the layout have axis title, the layout draw the legend position above x axis title or under y axis title.

Related Issue #335 

## Testing guidelines

<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

Currently, not add test.

![Chart example with legend position](https://user-images.githubusercontent.com/4014016/170288947-2c7a292f-83a7-4842-8214-b25c7ef85b17.png)

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ ] I have added relevant tests.
* [ ] I have documented all new additions.
