### PR TITLE
Remove redundant `vec![]` in `user_input` example

### DIFF
--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -182,7 +182,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .iter()
         .enumerate()
         .map(|(i, m)| {
-            let content = vec![Spans::from(Span::raw(format!("{}: {}", i, m)))];
+            let content = Spans::from(Span::raw(format!("{}: {}", i, m)));
             ListItem::new(content)
         })
         .collect();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->
I found `vec![]` is redundant in `user_input` example. This PR removes it.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

I ran `cargo run --example user_input` and tried to change the edit mode, edit the input, and add some lines to messages pane. It worked fine.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests. (No tests for the example)
* [x] I have documented all new additions. (No document for the example)
