### PR TITLE
feat: deref impl for backend types

### DIFF
--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -10,7 +10,7 @@ use termion::{
     event::Key,
     input::{MouseTerminal, TermRead},
     raw::IntoRawMode,
-    screen::{AlternateScreen, ToAlternateScreen, ToMainScreen},
+    screen::{ToAlternateScreen, ToMainScreen},
 };
 use tui::{
     backend::{Backend, TermionBackend},
@@ -26,12 +26,16 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
 
     // create app and run it
     let app = App::new("Termion demo", enhanced_graphics);
-    run_app(&mut terminal, app, tick_rate)?;
+    let res = run_app(&mut terminal, app, tick_rate);
 
     // restore terminal
     terminal.backend().suspend_raw_mode()?;
     write!(terminal.backend_mut(), "{}", ToMainScreen)?;
     terminal.show_cursor()?;
+
+    if let Err(err) = res {
+        println!("{:?}", err);
+    }
 
     Ok(())
 }

--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -33,7 +33,6 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
     write!(terminal.backend_mut(), "{}", ToMainScreen)?;
     terminal.show_cursor()?;
 
-    println!("bonsoir");
     Ok(())
 }
 

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -13,7 +13,10 @@ use crossterm::{
     },
     terminal::{self, Clear, ClearType},
 };
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    ops::{Deref, DerefMut},
+};
 
 pub struct CrosstermBackend<W: Write> {
     buffer: W,
@@ -38,6 +41,20 @@ where
 
     fn flush(&mut self) -> io::Result<()> {
         self.buffer.flush()
+    }
+}
+
+impl<W: Write> Deref for CrosstermBackend<W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+impl<W: Write> DerefMut for CrosstermBackend<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buffer
     }
 }
 

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -7,6 +7,7 @@ use crate::{
 use std::{
     fmt,
     io::{self, Write},
+    ops::{Deref, DerefMut},
 };
 
 pub struct TermionBackend<W>
@@ -35,6 +36,20 @@ where
 
     fn flush(&mut self) -> io::Result<()> {
         self.stdout.flush()
+    }
+}
+
+impl<W: Write> Deref for TermionBackend<W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stdout
+    }
+}
+
+impl<W: Write> DerefMut for TermionBackend<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stdout
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes #630 issue, and adds the implementation of the `std::ops::Deref` and `std::ops::DerefMut` traits on backend types `CrosstermBackend<W>` and `TermionBackend<W>`. This allows to access the methods of the underlying data of the backend types, especially the `RawTerminal::activate_raw_mode` and `RawTerminal::suspend_raw_mode` methods for `termion` backend.

The `termion` part of the demo example has also been modified. It now restores the terminal before ending the `main` function. Either way, the example hasn't been modified, but we can now display the errors after restoring the terminal like with the `crossterm` backend.

## Testing guidelines

Because it only concerns a trait implementation on the backend types and it doesn't concern any drawing issue, this PR doesn't need any new relevant tests.

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
