### PR TITLE
derive Copy for Direction

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -14,7 +14,7 @@ pub enum Corner {
     BottomLeft,
 }
 
-#[derive(Debug, Hash, Clone, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
     Horizontal,
     Vertical,


### PR DESCRIPTION
While similar enum like `Corner` implement `Copy` trait but `Direction` does not. Since this enum is simple it should make sense to derive this.

Suggested in #634

## Description
Derive Copy trait for `layouts::Direction`

## Testing guidelines
No longer have to call `.clone()` or will be better than `&_`

## Checklist

* [ x  ] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [ x ] I have added relevant tests.
* [ x ] I have documented all new additions.
