### PR TITLE
feat(widgets/list): allow padding selected using layout constraints

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -43,6 +43,20 @@ impl Constraint {
             Constraint::Min(m) => length.max(m),
         }
     }
+
+    /// returns the new target padding based on the constraint
+    pub fn apply_for_padding(&self, total_length: u16, current_padding: u16) -> u16 {
+        match *self {
+            Constraint::Percentage(p) => total_length * p / 100,
+            Constraint::Ratio(num, den) => {
+                let r = num * u32::from(total_length) / den;
+                r as u16
+            }
+            Constraint::Length(l) => total_length.min(l),
+            Constraint::Max(m) => current_padding.min(m),
+            Constraint::Min(m) => current_padding.max(m),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Consider padding when choosing offset/scrolling to selected item
resolves #328

## Description
This PR allows suggesting how many rows should be displayed above and below a selected item.

## Testing guidelines
I have included some tests in tests/widgets_list.rs

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [X] I have added relevant tests.
* [X] I have documented all new additions.
