### PR TITLE
doc: add tui-textarea as 3rd party widget library

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You can run all examples by running `cargo make run-examples` (require
 ### Third-party widgets
 
 * [tui-logger](https://github.com/gin66/tui-logger)
+* [tui-textarea](https://github.com/rhysd/tui-textarea): Simple yet powerful multi-line text editor widget supporting several key shortcuts, undo/redo, text search, etc.
 
 ### Apps using tui
 


### PR DESCRIPTION
## Description

Recently I'm working on a widget library for tui-rs, [tui-textarea](https://github.com/rhysd/tui-textarea). It is a simple yet powerful multi-line text editor widget supporting several key shortcuts, undo/redo, text search, etc.

Here is a screencast of example text editor using the widget:

<img src="https://raw.githubusercontent.com/rhysd/ss/master/tui-textarea/editor.gif" width=560 height=236 alt="editor example">

This PR adds the link to readme document.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->
Since this PR does not modify any source code, I tested nothing.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
