### PR TITLE
Use `SmolStr` to avoid bunch of heap allocations for `Cell`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ unicode-width = "0.1"
 termion = { version = "1.5", optional = true }
 crossterm = { version = "0.23", optional = true }
 serde = { version = "1", optional = true, features = ["derive"]}
+smol_str = "0.1"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Fixes #627

## Description

To render a `Buffer` instance, `height * length` of `String`s are allocated on heap because one `String` is allocated per one `Cell`. For example, my terminal requires `$LINES * $COLUMNS = 82 * 318 = 26076` of `String` allocations on heap to render an application with entire terminal screen.

Recently I found an awesome crate [`smol_str`](https://github.com/rust-analyzer/smol_str) maintained by rust-analyzer team. This crate provides a string type `SmolStr` with small string optimization (SSO). Its size is always the same as `String`. So size of `Cell` does not change. And it can contain a string without heap allocation up to 22 bytes. I believe almost all unicode grapheme clusters fit to the size. So almost all heap allocations around `Cell` can be removed by simply replacing `String` with `SmolStr`.

This PR replaces the `symbol` field of `Cell`. Since the field is public, this change will lead to major version bump (v0.19.0?). But it is not so big problem because `Cell` is very implementation details and typically TUI application authors don't access it directly.

Thanks to carefully designed `SmolStr`'s APIs, just replacing `String` with `SmolStr` almost worked and changes of this PR are very small. The difference between `SmolStr` and `String` is immutable or not. `symbol` field is now newly created instead of clearing its contents.

## Testing guidelines
- I ran all unit tests and confirmed they passed
- I ran all examples and checked they were working fine manually

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests. (I believe current test is sufficient)
* [x] I have documented all new additions.
