### PR TITLE
chore: explicitly set MSRV to 1.56.1 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]
 autoexamples = true
 edition = "2021"
+rust-version = "1.56.1"
 
 [badges]
 


### PR DESCRIPTION
## Description

This crate's MSRV is 1.56.1. But it is not declared as package metadata.

This PR sets [`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) metadata to `Cargo.toml` so that Clippy can run checks considering MSRV and users can check MSRV of their packages with tools such as [cargo-msrv](https://github.com/foresterre/cargo-msrv).

## Testing guidelines

I checked `cargo check` results and unit tests passed.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
