### PR TITLE
Add documentation for x_bounds, y_bounds

### DIFF
--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -384,11 +384,65 @@ where
         self
     }
 
+    /// Define the viewport of the canvas.
+    ///
+    /// Only the points whose coordinates are within the viewport are displayed. When you render
+    /// the canvas using Frame::render_widget, you give an area to draw the widget to (a Rect) and
+    /// the crate translates the floating point coordinates to those used by our internal terminal
+    /// representation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tui::style::Color;
+    /// # use tui::widgets::{Block, Borders};
+    /// # use tui::widgets::canvas::{Canvas, Map, MapResolution};
+    /// let canvas = Canvas::default()
+    ///     .block(Block::default().borders(Borders::ALL).title("World"))
+    ///     .paint(|ctx| {
+    ///         ctx.draw(&Map {
+    ///             color: Color::White,
+    ///             resolution: MapResolution::High,
+    ///         });
+    ///     })
+    ///     .x_bounds([-180.0, 180.0])
+    ///     .y_bounds([-90.0, 90.0]);
+    /// ```
+    ///
+    /// If you were to "zoom" to a certain part of the world you may want to choose different
+    /// bounds.
     pub fn x_bounds(mut self, bounds: [f64; 2]) -> Canvas<'a, F> {
         self.x_bounds = bounds;
         self
     }
 
+    /// Define the viewport of the canvas.
+    ///
+    /// Only the points whose coordinates are within the viewport are displayed. When you render
+    /// the canvas using Frame::render_widget, you give an area to draw the widget to (a Rect) and
+    /// the crate translates the floating point coordinates to those used by our internal terminal
+    /// representation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tui::style::Color;
+    /// # use tui::widgets::{Block, Borders};
+    /// # use tui::widgets::canvas::{Canvas, Map, MapResolution};
+    /// let canvas = Canvas::default()
+    ///     .block(Block::default().borders(Borders::ALL).title("World"))
+    ///     .paint(|ctx| {
+    ///         ctx.draw(&Map {
+    ///             color: Color::White,
+    ///             resolution: MapResolution::High,
+    ///         });
+    ///     })
+    ///     .x_bounds([-180.0, 180.0])
+    ///     .y_bounds([-90.0, 90.0]);
+    /// ```
+    ///
+    /// If you were to "zoom" to a certain part of the world you may want to choose different
+    /// bounds.
     pub fn y_bounds(mut self, bounds: [f64; 2]) -> Canvas<'a, F> {
         self.y_bounds = bounds;
         self


### PR DESCRIPTION
## Description

There is no description in docs for `Canvas::x_bounds` and `Canvas::y_bounds`, but there is a [question](https://github.com/fdehau/tui-rs/issues/286) about that with response of the author. So this PR puts this response as documentation for the methods with some small corrections and formatting.

## Testing guidelines

This PR does not add any code, but all code fragments in documentation are valid & buildable.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
