### PR TITLE
Title on bottom

### DIFF
--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -48,6 +48,8 @@ pub struct Block<'a> {
     /// Title alignment. The default is top left of the block, but one can choose to place
     /// title in the top middle, or top right of the block
     title_alignment: Alignment,
+    /// Whether or not title goes on top or bottom row of the block
+    title_on_bottom: bool,
     /// Visible borders
     borders: Borders,
     /// Border style
@@ -64,6 +66,7 @@ impl<'a> Default for Block<'a> {
         Block {
             title: None,
             title_alignment: Alignment::Left,
+            title_on_bottom: false,
             borders: Borders::NONE,
             border_style: Default::default(),
             border_type: BorderType::Plain,
@@ -95,6 +98,11 @@ impl<'a> Block<'a> {
 
     pub fn title_alignment(mut self, alignment: Alignment) -> Block<'a> {
         self.title_alignment = alignment;
+        self
+    }
+
+    pub fn title_on_bottom(mut self) -> Block<'a> {
+        self.title_on_bottom = true;
         self
     }
 
@@ -230,7 +238,11 @@ impl<'a> Widget for Block<'a> {
             };
 
             let title_x = area.left() + title_dx;
-            let title_y = area.top();
+            let title_y = if self.title_on_bottom {
+                area.bottom() - 1
+            } else {
+                area.top()
+            };
 
             buf.set_spans(title_x, title_y, &title, title_area_width);
         }
@@ -571,3 +583,4 @@ mod tests {
         );
     }
 }
+

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -344,3 +344,137 @@ fn widgets_block_title_alignment() {
         Buffer::with_lines(vec!["         Title ", "               "]),
     );
 }
+
+#[test]
+fn widgets_block_title_alignment_bottom() {
+    let test_case = |alignment, borders, expected| {
+        let backend = TestBackend::new(15, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let block = Block::default()
+            .title(Span::styled("Title", Style::default()))
+            .title_alignment(alignment)
+            .title_on_bottom()
+            .borders(borders);
+
+        let area = Rect {
+            x: 1,
+            y: 0,
+            width: 13,
+            height: 2,
+        };
+
+        terminal
+            .draw(|f| {
+                f.render_widget(block, area);
+            })
+            .unwrap();
+
+        terminal.backend().assert_buffer(&expected);
+    };
+
+    // title bottom-left with all borders
+    test_case(
+        Alignment::Left,
+        Borders::ALL,
+        Buffer::with_lines(vec![" ┌───────────┐ ", " └Title──────┘ "]),
+    );
+
+    // title bottom-left without bottom border
+    test_case(
+        Alignment::Left,
+        Borders::LEFT | Borders::TOP | Borders::RIGHT,
+        Buffer::with_lines(vec![" ┌───────────┐ ", " └Title──────┘ "]),
+    );
+
+    // title bottom-left with no left border
+    test_case(
+        Alignment::Left,
+        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ────────────┐ ", " Title───────┘ "]),
+    );
+
+    // title bottom-left without right border
+    test_case(
+        Alignment::Left,
+        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ┌──────────── ", " └Title─────── "]),
+    );
+
+    // title bottom-left without borders
+    test_case(
+        Alignment::Left,
+        Borders::NONE,
+        Buffer::with_lines(vec!["               ", " Title         "]),
+    );
+
+    // title center with all borders
+    test_case(
+        Alignment::Center,
+        Borders::ALL,
+        Buffer::with_lines(vec![" ┌───────────┐ ", " └───Title───┘ "]),
+    );
+
+    // title center without bottom border
+    test_case(
+        Alignment::Center,
+        Borders::LEFT | Borders::TOP | Borders::RIGHT,
+        Buffer::with_lines(vec![" ┌───────────┐ ", " └   Title   ┘ "]),
+    );
+
+    // title center with no left border
+    test_case(
+        Alignment::Center,
+        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ────────────┐ ", " ────Title───┘ "]),
+    );
+
+    // title center without right border
+    test_case(
+        Alignment::Center,
+        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ┌──────────── ", " └───Title──── "]),
+    );
+
+    // title center without borders
+    test_case(
+        Alignment::Center,
+        Borders::NONE,
+        Buffer::with_lines(vec!["               ", "     Title     "]),
+    );
+
+    // title bottom-right with all borders
+    test_case(
+        Alignment::Right,
+        Borders::ALL,
+        Buffer::with_lines(vec![" ┌───────────┐ ", " └──────Title┘ "]),
+    );
+
+    // title bottom-right without bottom border
+    test_case(
+        Alignment::Right,
+        Borders::LEFT | Borders::TOP | Borders::RIGHT,
+        Buffer::with_lines(vec![" ┌───────────┐ ", " └      Title┘ "]),
+    );
+
+    // title bottom-right with no left border
+    test_case(
+        Alignment::Right,
+        Borders::TOP | Borders::RIGHT | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ────────────┐ ", " ───────Title┘ "]),
+    );
+
+    // title bottom-right without right border
+    test_case(
+        Alignment::Right,
+        Borders::LEFT | Borders::TOP | Borders::BOTTOM,
+        Buffer::with_lines(vec![" ┌──────────── ", " └───────Title "]),
+    );
+
+    // title bottom-right without borders
+    test_case(
+        Alignment::Right,
+        Borders::NONE,
+        Buffer::with_lines(vec!["               ", "         Title "]),
+    );
+}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->
Before you could only put the title on the top row of a block.  Now you can put it on the bottom row! Revolutionary.

In the future, implementing an option for both a bottom and top title is possible, but seems unnecessary considering you could just manually have a `Layout` and do the work yourself at that point, and having support for title wizardry seems pointless.  The farthest you could go is having an option to actually move the title everywhere; it's an easy extension and seems like something that would normally be built-in.  Hence here it is; you can do top and bottom, left right and center.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

When creating a `Block` with, say, `Block::default().title()`, slap on a `.title_on_bottom()`.  Check `tests/widget_block.rs` for the tests, which are just a copy of the alignment tests.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.
