### PR TITLE
Add symbols to graph marker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ A library to build rich terminal user interfaces or dashboards
 """
 documentation = "https://docs.rs/tui/0.19.0/tui/"
 keywords = ["tui", "terminal", "dashboard"]
-repository = "https://github.com/fdehau/tui-rs"
+repository = "https://github.com/V8gaming/tui-rs"
 readme = "README.md"
 license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ A library to build rich terminal user interfaces or dashboards
 """
 documentation = "https://docs.rs/tui/0.19.0/tui/"
 keywords = ["tui", "terminal", "dashboard"]
-repository = "https://github.com/V8gaming/tui-rs"
+repository = "https://github.com/fdehau/tui-rs"
 readme = "README.md"
 license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -18,15 +18,21 @@ use tui::{
     Frame, Terminal,
 };
 
-const DATA: [(f64, f64); 5] = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0)];
-const DATA2: [(f64, f64); 7] = [
-    (0.0, 0.0),
-    (10.0, 1.0),
-    (20.0, 0.5),
-    (30.0, 1.5),
-    (40.0, 1.0),
-    (50.0, 2.5),
-    (60.0, 3.0),
+const DATA: [(f64, f64, bool); 5] = [
+    (0.0, 0.0, true), 
+    (1.0, 1.0, true), 
+    (2.0, 2.0, true), 
+    (3.0, 3.0, true), 
+    (4.0, 4.0, true)
+];
+const DATA2: [(f64, f64, bool); 7] = [
+    (0.0, 0.0, true),
+    (10.0, 1.0, true),
+    (20.0, 0.5, true),
+    (30.0, 1.5, true),
+    (40.0, 1.0, true),
+    (50.0, 2.5, true),
+    (60.0, 3.0, true),
 ];
 
 #[derive(Clone)]
@@ -49,9 +55,9 @@ impl SinSignal {
 }
 
 impl Iterator for SinSignal {
-    type Item = (f64, f64);
+    type Item = (f64, f64, bool);
     fn next(&mut self) -> Option<Self::Item> {
-        let point = (self.x, (self.x * 1.0 / self.period).sin() * self.scale);
+        let point = (self.x, (self.x * 1.0 / self.period).sin() * self.scale, true);
         self.x += self.interval;
         Some(point)
     }
@@ -59,9 +65,9 @@ impl Iterator for SinSignal {
 
 struct App {
     signal1: SinSignal,
-    data1: Vec<(f64, f64)>,
+    data1: Vec<(f64, f64, bool)>,
     signal2: SinSignal,
-    data2: Vec<(f64, f64)>,
+    data2: Vec<(f64, f64, bool)>,
     window: [f64; 2],
 }
 
@@ -69,8 +75,8 @@ impl App {
     fn new() -> App {
         let mut signal1 = SinSignal::new(0.2, 3.0, 18.0);
         let mut signal2 = SinSignal::new(0.1, 2.0, 10.0);
-        let data1 = signal1.by_ref().take(200).collect::<Vec<(f64, f64)>>();
-        let data2 = signal2.by_ref().take(200).collect::<Vec<(f64, f64)>>();
+        let data1 = signal1.by_ref().take(200).collect::<Vec<(f64, f64, bool)>>();
+        let data2 = signal2.by_ref().take(200).collect::<Vec<(f64, f64, bool)>>();
         App {
             signal1,
             data1,

--- a/examples/demo/app.rs
+++ b/examples/demo/app.rs
@@ -108,9 +108,9 @@ impl SinSignal {
 }
 
 impl Iterator for SinSignal {
-    type Item = (f64, f64);
+    type Item = (f64, f64, bool);
     fn next(&mut self) -> Option<Self::Item> {
-        let point = (self.x, (self.x * 1.0 / self.period).sin() * self.scale);
+        let point = (self.x, (self.x * 1.0 / self.period).sin() * self.scale, true);
         self.x += self.interval;
         Some(point)
     }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -230,89 +230,137 @@ pub enum Marker {
     Block,
     /// Up to 8 points per cell
     Braille,
-    /// extra markers from 'block'
-    Blocks(Block),
-    /// extra markers from 'bar'
-    Bars(Bar),
-    /// extra markers from 'line'
-    Lines(Line),
-    
+    /// One point per cell in shapes in block
+    Blocks(Blocks),
+    /// One point per cell in shapes in bar
+    Bars(Bars),
+    /// One point per cell in shapes in line
+    Lines(Lines),
 }
 #[derive(Debug, Clone, Copy)]
 pub enum Blocks {
-    /// One point per cell completely filled
+    /// shape of "█"
     FULL,
+    /// shape of "▉"
     SevenEights,
+    /// shape of "▊"
     ThreeQuarters,
+    /// shape of "▋"
     FiveEighths,
+    /// shape of "▌"
     HALF,
+    /// shape of "▍"
     ThreeEighths,
+    /// shape of "▎"
     OneQuarter,
+    /// shape of "▏"
     OneEighth,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum Bars {
-    /// One point per cell completely filled
+    /// shape of "█"
     FULL,
+    /// shape of "▇"
     SevenEights,
+    /// shape of "▆"
     ThreeQuarters,
+    /// shape of "▅"
     FiveEighths,
+    /// shape of "▄"
     HALF,
+    /// shape of "▃"
     ThreeEighths,
+    /// shape of "▂"
     OneQuarter,
+    /// shape of "▁"
     OneEighth,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum Lines {
-    /// One point per cell completely filled
+    /// shape of "│"
     VERTICAL,
+    /// shape of "║"
     DoubleVertical,
+    /// shape of "┃";
     ThickVertical,
-
+    
+    /// shape of "─"
     HORIZONTAL,
+    /// shape of "═"
     DoubleHorizontal,
+    /// shape of "━"
     ThickHorizontal,
 
+    /// shape of "┐"
     TopRight,
+    /// shape of "╗"
     DoubleTopRight,
+    /// shape of "┓"
     ThickTopRight,
+    /// shape of "╮"
     RoundedTopRight,
 
+    /// shape of "┌"
     TopLeft,
+    /// shape of "╔"
     DoubleTopLeft,
+    /// shape of "┏"
     ThickTopLeft,
+    /// shape of "╭"
     RoundedTopLeft,
 
+    /// shape of "┘"
     BottomRight,
+    /// shape of "╝"
     DoubleBottomRight,
+    /// shape of "┛"
     ThickBottomRight,
+    /// shape of "╯"
     RoundedBottomRight,
 
+    /// shape of "└"
     BottomLeft,
+    /// shape of "╚"
     DoubleBottomLeft,
+    /// shape of "┗"
     ThickBottomLeft,
+    /// shape of "╰"
     RoundedBottomLeft,
 
+    /// shape of "┤"
     VerticalLeft,
+    /// shape of "╣"
     DoubleVerticalLeft,
+    /// shape of "┫"
     ThickVerticalLeft,
 
+    /// shape of "├"
     VerticalRight,
+    /// shape of "╠"
     DoubleVerticalRight,
+    /// shape of "┣"
     ThickVerticalRight,
 
+    /// shape of "┬"
     HorizontalDown,
+    /// shape of "╦"
     DoubleHorizontalDown,
+    /// shape of "┳"
     ThickHorizontalDown,
 
+    /// shape of "┴"
     HorizontalUp,
+    /// shape of "╩"
     DoubleHorizontalUp,
+    /// shape of "┻"
     ThickHorizontalUp,
 
+    /// shape of "┼"
     CROSS,
+    /// shape of "╬"
     DoubleCross,
+    /// shape of "╋"
     ThickCross,
-    
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -230,6 +230,89 @@ pub enum Marker {
     Block,
     /// Up to 8 points per cell
     Braille,
+    /// extra markers from 'block'
+    ExtraBlock(Block),
+    /// extra markers from 'bar'
+    ExtraBar(Bar),
+    /// extra markers from 'line'
+    ExtraLine(Line),
+    
+}
+#[derive(Debug, Clone, Copy)]
+pub enum Block {
     /// One point per cell completely filled
     FULL,
+    SevenEights,
+    ThreeQuarters,
+    FiveEighths,
+    HALF,
+    ThreeEighths,
+    OneQuarter,
+    OneEighth,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Bar {
+    /// One point per cell completely filled
+    FULL,
+    SevenEights,
+    ThreeQuarters,
+    FiveEighths,
+    HALF,
+    ThreeEighths,
+    OneQuarter,
+    OneEighth,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Line {
+    /// One point per cell completely filled
+    VERTICAL,
+    DoubleVertical,
+    ThickVertical,
+
+    HORIZONTAL,
+    DoubleHorizontal,
+    ThickHorizontal,
+
+    TopRight,
+    DoubleTopRight,
+    ThickTopRight,
+    RoundedTopRight,
+
+    TopLeft,
+    DoubleTopLeft,
+    ThickTopLeft,
+    RoundedTopLeft,
+
+    BottomRight,
+    DoubleBottomRight,
+    ThickBottomRight,
+    RoundedBottomRight,
+
+    BottomLeft,
+    DoubleBottomLeft,
+    ThickBottomLeft,
+    RoundedBottomLeft,
+
+    VerticalLeft,
+    DoubleVerticalLeft,
+    ThickVerticalLeft,
+
+    VerticalRight,
+    DoubleVerticalRight,
+    ThickVerticalRight,
+
+    HorizontalDown,
+    DoubleHorizontalDown,
+    ThickHorizontalDown,
+
+    HorizontalUp,
+    DoubleHorizontalUp,
+    ThickHorizontalUp,
+
+    CROSS,
+    DoubleCross,
+    ThickCross,
+    
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -230,4 +230,6 @@ pub enum Marker {
     Block,
     /// Up to 8 points per cell
     Braille,
+    /// One point per cell completely filled
+    FULL,
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -231,15 +231,15 @@ pub enum Marker {
     /// Up to 8 points per cell
     Braille,
     /// extra markers from 'block'
-    ExtraBlock(Block),
+    Blocks(Block),
     /// extra markers from 'bar'
-    ExtraBar(Bar),
+    Bars(Bar),
     /// extra markers from 'line'
-    ExtraLine(Line),
+    Lines(Line),
     
 }
 #[derive(Debug, Clone, Copy)]
-pub enum Block {
+pub enum Blocks {
     /// One point per cell completely filled
     FULL,
     SevenEights,
@@ -252,7 +252,7 @@ pub enum Block {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum Bar {
+pub enum Bars {
     /// One point per cell completely filled
     FULL,
     SevenEights,
@@ -265,7 +265,7 @@ pub enum Bar {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum Line {
+pub enum Lines {
     /// One point per cell completely filled
     VERTICAL,
     DoubleVertical,

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -264,6 +264,8 @@ impl<'a> Context<'a> {
             symbols::Marker::Dot => Box::new(CharGrid::new(width, height, '•')),
             symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
+            // added FULL so I can graph a 'background'
+            symbols::Marker::FULL => Box::new(CharGrid::new(width, height +2, '█'))
         };
         Context {
             x_bounds,

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -264,85 +264,75 @@ impl<'a> Context<'a> {
             symbols::Marker::Dot => Box::new(CharGrid::new(width, height, '•')),
             symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
-            // added FULL so I can graph a 'background'
-            symbols::Marker::Blocks(marker) => {
-                match marker {
-                    symbols::Block::FULL => Box::new(CharGrid::new(width, height+2, '█')),
-                    symbols::Block::SevenEights => Box::new(CharGrid::new(width, height, '▉')),
-                    symbols::Block::ThreeQuarters => Box::new(CharGrid::new(width, height, '▊')),
-                    symbols::Block::FiveEighths => Box::new(CharGrid::new(width, height, '▋')),
-                    symbols::Block::HALF => Box::new(CharGrid::new(width, height, '▌')),
-                    symbols::Block::ThreeEighths => Box::new(CharGrid::new(width, height, '▍')),
-                    symbols::Block::OneQuarter => Box::new(CharGrid::new(width, height, '▎')),
-                    symbols::Block::OneEighth => Box::new(CharGrid::new(width, height, '▏')),
+            symbols::Marker::Blocks(marker) => match marker {
+                symbols::Blocks::FULL => Box::new(CharGrid::new(width, height, '█')),
+                symbols::Blocks::SevenEights => Box::new(CharGrid::new(width, height, '▉')),
+                symbols::Blocks::ThreeQuarters => Box::new(CharGrid::new(width, height, '▊')),
+                symbols::Blocks::FiveEighths => Box::new(CharGrid::new(width, height, '▋')),
+                symbols::Blocks::HALF => Box::new(CharGrid::new(width, height, '▌')),
+                symbols::Blocks::ThreeEighths => Box::new(CharGrid::new(width, height, '▍')),
+                symbols::Blocks::OneQuarter => Box::new(CharGrid::new(width, height, '▎')),
+                symbols::Blocks::OneEighth => Box::new(CharGrid::new(width, height, '▏')),
+            },
+            symbols::Marker::Bars(marker) => match marker {
+                symbols::Bars::FULL => Box::new(CharGrid::new(width, height, '█')),
+                symbols::Bars::SevenEights => Box::new(CharGrid::new(width, height, '▇')),
+                symbols::Bars::ThreeQuarters => Box::new(CharGrid::new(width, height, '▆')),
+                symbols::Bars::FiveEighths => Box::new(CharGrid::new(width, height, '▅')),
+                symbols::Bars::HALF => Box::new(CharGrid::new(width, height, '▄')),
+                symbols::Bars::ThreeEighths => Box::new(CharGrid::new(width, height, '▃')),
+                symbols::Bars::OneQuarter => Box::new(CharGrid::new(width, height, '▂')),
+                symbols::Bars::OneEighth => Box::new(CharGrid::new(width, height, '▁')),
+            },
+            symbols::Marker::Lines(marker) => match marker {
+                symbols::Lines::VERTICAL => Box::new(CharGrid::new(width, height, '│')),
+                symbols::Lines::DoubleVertical => Box::new(CharGrid::new(width, height, '║')),
+                symbols::Lines::ThickVertical => Box::new(CharGrid::new(width, height, '┃')),
 
-                }
-            }
-            symbols::Marker::Bars(marker) => {
-                match marker {
-                    symbols::Bar::FULL => Box::new(CharGrid::new(width, height+2, '█')),
-                    symbols::Bar::SevenEights => Box::new(CharGrid::new(width, height, '▇')),
-                    symbols::Bar::ThreeQuarters => Box::new(CharGrid::new(width, height, '▆')),
-                    symbols::Bar::FiveEighths => Box::new(CharGrid::new(width, height, '▅')),
-                    symbols::Bar::HALF => Box::new(CharGrid::new(width, height, '▄')),
-                    symbols::Bar::ThreeEighths => Box::new(CharGrid::new(width, height, '▃')),
-                    symbols::Bar::OneQuarter => Box::new(CharGrid::new(width, height, '▂')),
-                    symbols::Bar::OneEighth => Box::new(CharGrid::new(width, height, '▁')),
+                symbols::Lines::HORIZONTAL => Box::new(CharGrid::new(width, height, '─')),
+                symbols::Lines::DoubleHorizontal => Box::new(CharGrid::new(width, height, '═')),
+                symbols::Lines::ThickHorizontal => Box::new(CharGrid::new(width, height, '━')),
 
-                }
-            }
-            symbols::Marker::Lines(marker ) => {
-                match marker {
-                    symbols::Line::VERTICAL => Box::new(CharGrid::new(width, height, '│')),
-                    symbols::Line::DoubleVertical => Box::new(CharGrid::new(width, height, '║')),
-                    symbols::Line::ThickVertical => Box::new(CharGrid::new(width, height, '┃')),
-                    
-                    symbols::Line::HORIZONTAL => Box::new(CharGrid::new(width, height, '─')),
-                    symbols::Line::DoubleHorizontal => Box::new(CharGrid::new(width, height, '═')),
-                    symbols::Line::ThickHorizontal => Box::new(CharGrid::new(width, height, '━')),
+                symbols::Lines::TopRight => Box::new(CharGrid::new(width, height, '┐')),
+                symbols::Lines::DoubleTopRight => Box::new(CharGrid::new(width, height, '╗')),
+                symbols::Lines::ThickTopRight => Box::new(CharGrid::new(width, height, '┓')),
+                symbols::Lines::RoundedTopRight => Box::new(CharGrid::new(width, height, '╮')),
 
-                    symbols::Line::TopRight => Box::new(CharGrid::new(width, height, '┐')),
-                    symbols::Line::DoubleTopRight => Box::new(CharGrid::new(width, height, '╗')),
-                    symbols::Line::ThickTopRight => Box::new(CharGrid::new(width, height, '┓')),
-                    symbols::Line::RoundedTopRight => Box::new(CharGrid::new(width, height, '╮')),
+                symbols::Lines::TopLeft => Box::new(CharGrid::new(width, height, '┌')),
+                symbols::Lines::DoubleTopLeft => Box::new(CharGrid::new(width, height, '╔')),
+                symbols::Lines::ThickTopLeft => Box::new(CharGrid::new(width, height, '┏')),
+                symbols::Lines::RoundedTopLeft => Box::new(CharGrid::new(width, height, '╭')),
 
-                    symbols::Line::TopLeft => Box::new(CharGrid::new(width, height, '┌')),
-                    symbols::Line::DoubleTopLeft => Box::new(CharGrid::new(width, height, '╔')),
-                    symbols::Line::ThickTopLeft => Box::new(CharGrid::new(width, height, '┏')),
-                    symbols::Line::RoundedTopLeft => Box::new(CharGrid::new(width, height, '╭')),
+                symbols::Lines::BottomRight => Box::new(CharGrid::new(width, height, '┘')),
+                symbols::Lines::DoubleBottomRight => Box::new(CharGrid::new(width, height, '╝')),
+                symbols::Lines::ThickBottomRight => Box::new(CharGrid::new(width, height, '┛')),
+                symbols::Lines::RoundedBottomRight => Box::new(CharGrid::new(width, height, '╯')),
 
-                    symbols::Line::BottomRight => Box::new(CharGrid::new(width, height, '┘')),
-                    symbols::Line::DoubleBottomRight => Box::new(CharGrid::new(width, height, '╝')),
-                    symbols::Line::ThickBottomRight => Box::new(CharGrid::new(width, height, '┛')),
-                    symbols::Line::RoundedBottomRight => Box::new(CharGrid::new(width, height, '╯')),
+                symbols::Lines::BottomLeft => Box::new(CharGrid::new(width, height, '└')),
+                symbols::Lines::DoubleBottomLeft => Box::new(CharGrid::new(width, height, '╚')),
+                symbols::Lines::ThickBottomLeft => Box::new(CharGrid::new(width, height, '┗')),
+                symbols::Lines::RoundedBottomLeft => Box::new(CharGrid::new(width, height, '╰')),
 
-                    symbols::Line::BottomLeft => Box::new(CharGrid::new(width, height, '└')),
-                    symbols::Line::DoubleBottomLeft => Box::new(CharGrid::new(width, height, '╚')),
-                    symbols::Line::ThickBottomLeft => Box::new(CharGrid::new(width, height, '┗')),
-                    symbols::Line::RoundedBottomLeft => Box::new(CharGrid::new(width, height, '╰')),
+                symbols::Lines::VerticalLeft => Box::new(CharGrid::new(width, height, '┤')),
+                symbols::Lines::DoubleVerticalLeft => Box::new(CharGrid::new(width, height, '╣')),
+                symbols::Lines::ThickVerticalLeft => Box::new(CharGrid::new(width, height, '┫')),
 
-                    symbols::Line::VerticalLeft => Box::new(CharGrid::new(width, height, '┤')),
-                    symbols::Line::DoubleVerticalLeft => Box::new(CharGrid::new(width, height, '╣')),
-                    symbols::Line::ThickVerticalLeft => Box::new(CharGrid::new(width, height, '┫')),
-                    
-                    symbols::Line::VerticalRight => Box::new(CharGrid::new(width, height, '├')),
-                    symbols::Line::DoubleVerticalRight => Box::new(CharGrid::new(width, height, '╠')),
-                    symbols::Line::ThickVerticalRight => Box::new(CharGrid::new(width, height, '┣')),
+                symbols::Lines::VerticalRight => Box::new(CharGrid::new(width, height, '├')),
+                symbols::Lines::DoubleVerticalRight => Box::new(CharGrid::new(width, height, '╠')),
+                symbols::Lines::ThickVerticalRight => Box::new(CharGrid::new(width, height, '┣')),
 
-                    symbols::Line::HorizontalDown => Box::new(CharGrid::new(width, height, '┬')),
-                    symbols::Line::DoubleHorizontalDown => Box::new(CharGrid::new(width, height, '╦')),
-                    symbols::Line::ThickHorizontalDown => Box::new(CharGrid::new(width, height, '┳')),
+                symbols::Lines::HorizontalDown => Box::new(CharGrid::new(width, height, '┬')),
+                symbols::Lines::DoubleHorizontalDown => Box::new(CharGrid::new(width, height, '╦')),
+                symbols::Lines::ThickHorizontalDown => Box::new(CharGrid::new(width, height, '┳')),
 
-                    symbols::Line::HorizontalUp => Box::new(CharGrid::new(width, height, '┴')),
-                    symbols::Line::DoubleHorizontalUp => Box::new(CharGrid::new(width, height, '╩')),
-                    symbols::Line::ThickHorizontalUp => Box::new(CharGrid::new(width, height, '┻')),
+                symbols::Lines::HorizontalUp => Box::new(CharGrid::new(width, height, '┴')),
+                symbols::Lines::DoubleHorizontalUp => Box::new(CharGrid::new(width, height, '╩')),
+                symbols::Lines::ThickHorizontalUp => Box::new(CharGrid::new(width, height, '┻')),
 
-                    symbols::Line::CROSS => Box::new(CharGrid::new(width, height, '┼')),
-                    symbols::Line::DoubleCross => Box::new(CharGrid::new(width, height, '╬')),
-                    symbols::Line::ThickCross => Box::new(CharGrid::new(width, height, '╋')),
-
-                }
-            }
+                symbols::Lines::CROSS => Box::new(CharGrid::new(width, height, '┼')),
+                symbols::Lines::DoubleCross => Box::new(CharGrid::new(width, height, '╬')),
+                symbols::Lines::ThickCross => Box::new(CharGrid::new(width, height, '╋')),
+            },
         };
         Context {
             x_bounds,

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -265,7 +265,7 @@ impl<'a> Context<'a> {
             symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
             // added FULL so I can graph a 'background'
-            symbols::Marker::ExtraBlock(marker) => {
+            symbols::Marker::Blocks(marker) => {
                 match marker {
                     symbols::Block::FULL => Box::new(CharGrid::new(width, height+2, '█')),
                     symbols::Block::SevenEights => Box::new(CharGrid::new(width, height, '▉')),
@@ -278,7 +278,7 @@ impl<'a> Context<'a> {
 
                 }
             }
-            symbols::Marker::ExtraBar(marker) => {
+            symbols::Marker::Bars(marker) => {
                 match marker {
                     symbols::Bar::FULL => Box::new(CharGrid::new(width, height+2, '█')),
                     symbols::Bar::SevenEights => Box::new(CharGrid::new(width, height, '▇')),
@@ -291,7 +291,7 @@ impl<'a> Context<'a> {
 
                 }
             }
-            symbols::Marker::ExtraLine(marker ) => {
+            symbols::Marker::Lines(marker ) => {
                 match marker {
                     symbols::Line::VERTICAL => Box::new(CharGrid::new(width, height, '│')),
                     symbols::Line::DoubleVertical => Box::new(CharGrid::new(width, height, '║')),

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -265,7 +265,84 @@ impl<'a> Context<'a> {
             symbols::Marker::Block => Box::new(CharGrid::new(width, height, '▄')),
             symbols::Marker::Braille => Box::new(BrailleGrid::new(width, height)),
             // added FULL so I can graph a 'background'
-            symbols::Marker::FULL => Box::new(CharGrid::new(width, height +2, '█'))
+            symbols::Marker::ExtraBlock(marker) => {
+                match marker {
+                    symbols::Block::FULL => Box::new(CharGrid::new(width, height+2, '█')),
+                    symbols::Block::SevenEights => Box::new(CharGrid::new(width, height, '▉')),
+                    symbols::Block::ThreeQuarters => Box::new(CharGrid::new(width, height, '▊')),
+                    symbols::Block::FiveEighths => Box::new(CharGrid::new(width, height, '▋')),
+                    symbols::Block::HALF => Box::new(CharGrid::new(width, height, '▌')),
+                    symbols::Block::ThreeEighths => Box::new(CharGrid::new(width, height, '▍')),
+                    symbols::Block::OneQuarter => Box::new(CharGrid::new(width, height, '▎')),
+                    symbols::Block::OneEighth => Box::new(CharGrid::new(width, height, '▏')),
+
+                }
+            }
+            symbols::Marker::ExtraBar(marker) => {
+                match marker {
+                    symbols::Bar::FULL => Box::new(CharGrid::new(width, height+2, '█')),
+                    symbols::Bar::SevenEights => Box::new(CharGrid::new(width, height, '▇')),
+                    symbols::Bar::ThreeQuarters => Box::new(CharGrid::new(width, height, '▆')),
+                    symbols::Bar::FiveEighths => Box::new(CharGrid::new(width, height, '▅')),
+                    symbols::Bar::HALF => Box::new(CharGrid::new(width, height, '▄')),
+                    symbols::Bar::ThreeEighths => Box::new(CharGrid::new(width, height, '▃')),
+                    symbols::Bar::OneQuarter => Box::new(CharGrid::new(width, height, '▂')),
+                    symbols::Bar::OneEighth => Box::new(CharGrid::new(width, height, '▁')),
+
+                }
+            }
+            symbols::Marker::ExtraLine(marker ) => {
+                match marker {
+                    symbols::Line::VERTICAL => Box::new(CharGrid::new(width, height, '│')),
+                    symbols::Line::DoubleVertical => Box::new(CharGrid::new(width, height, '║')),
+                    symbols::Line::ThickVertical => Box::new(CharGrid::new(width, height, '┃')),
+                    
+                    symbols::Line::HORIZONTAL => Box::new(CharGrid::new(width, height, '─')),
+                    symbols::Line::DoubleHorizontal => Box::new(CharGrid::new(width, height, '═')),
+                    symbols::Line::ThickHorizontal => Box::new(CharGrid::new(width, height, '━')),
+
+                    symbols::Line::TopRight => Box::new(CharGrid::new(width, height, '┐')),
+                    symbols::Line::DoubleTopRight => Box::new(CharGrid::new(width, height, '╗')),
+                    symbols::Line::ThickTopRight => Box::new(CharGrid::new(width, height, '┓')),
+                    symbols::Line::RoundedTopRight => Box::new(CharGrid::new(width, height, '╮')),
+
+                    symbols::Line::TopLeft => Box::new(CharGrid::new(width, height, '┌')),
+                    symbols::Line::DoubleTopLeft => Box::new(CharGrid::new(width, height, '╔')),
+                    symbols::Line::ThickTopLeft => Box::new(CharGrid::new(width, height, '┏')),
+                    symbols::Line::RoundedTopLeft => Box::new(CharGrid::new(width, height, '╭')),
+
+                    symbols::Line::BottomRight => Box::new(CharGrid::new(width, height, '┘')),
+                    symbols::Line::DoubleBottomRight => Box::new(CharGrid::new(width, height, '╝')),
+                    symbols::Line::ThickBottomRight => Box::new(CharGrid::new(width, height, '┛')),
+                    symbols::Line::RoundedBottomRight => Box::new(CharGrid::new(width, height, '╯')),
+
+                    symbols::Line::BottomLeft => Box::new(CharGrid::new(width, height, '└')),
+                    symbols::Line::DoubleBottomLeft => Box::new(CharGrid::new(width, height, '╚')),
+                    symbols::Line::ThickBottomLeft => Box::new(CharGrid::new(width, height, '┗')),
+                    symbols::Line::RoundedBottomLeft => Box::new(CharGrid::new(width, height, '╰')),
+
+                    symbols::Line::VerticalLeft => Box::new(CharGrid::new(width, height, '┤')),
+                    symbols::Line::DoubleVerticalLeft => Box::new(CharGrid::new(width, height, '╣')),
+                    symbols::Line::ThickVerticalLeft => Box::new(CharGrid::new(width, height, '┫')),
+                    
+                    symbols::Line::VerticalRight => Box::new(CharGrid::new(width, height, '├')),
+                    symbols::Line::DoubleVerticalRight => Box::new(CharGrid::new(width, height, '╠')),
+                    symbols::Line::ThickVerticalRight => Box::new(CharGrid::new(width, height, '┣')),
+
+                    symbols::Line::HorizontalDown => Box::new(CharGrid::new(width, height, '┬')),
+                    symbols::Line::DoubleHorizontalDown => Box::new(CharGrid::new(width, height, '╦')),
+                    symbols::Line::ThickHorizontalDown => Box::new(CharGrid::new(width, height, '┳')),
+
+                    symbols::Line::HorizontalUp => Box::new(CharGrid::new(width, height, '┴')),
+                    symbols::Line::DoubleHorizontalUp => Box::new(CharGrid::new(width, height, '╩')),
+                    symbols::Line::ThickHorizontalUp => Box::new(CharGrid::new(width, height, '┻')),
+
+                    symbols::Line::CROSS => Box::new(CharGrid::new(width, height, '┼')),
+                    symbols::Line::DoubleCross => Box::new(CharGrid::new(width, height, '╬')),
+                    symbols::Line::ThickCross => Box::new(CharGrid::new(width, height, '╋')),
+
+                }
+            }
         };
         Context {
             x_bounds,

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -12,15 +12,13 @@ pub struct Points<'a> {
 
 impl<'a> Shape for Points<'a> {
     fn draw(&self, painter: &mut Painter) {
+        println!("{:?}", self.coords);
         for (x, y, drawed) in self.coords {
             if *drawed {
                 if let Some((x, y)) = painter.get_point(*x, *y) {
                     painter.paint(x, y, self.color);
                 }
-            } else if let Some((x, y)) = painter.get_point(*x, *y) {
-                //painter.paint(x, y, Color::Reset);
             }
-
         }
     }
 }

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -6,16 +6,21 @@ use crate::{
 /// A shape to draw a group of points with the given color
 #[derive(Debug, Clone)]
 pub struct Points<'a> {
-    pub coords: &'a [(f64, f64)],
+    pub coords: &'a [(f64, f64, bool)],
     pub color: Color,
 }
 
 impl<'a> Shape for Points<'a> {
     fn draw(&self, painter: &mut Painter) {
-        for (x, y) in self.coords {
-            if let Some((x, y)) = painter.get_point(*x, *y) {
-                painter.paint(x, y, self.color);
+        for (x, y, drawed) in self.coords {
+            if *drawed {
+                if let Some((x, y)) = painter.get_point(*x, *y) {
+                    painter.paint(x, y, self.color);
+                }
+            } else if let Some((x, y)) = painter.get_point(*x, *y) {
+                painter.paint(x, y, Color::Reset);
             }
+
         }
     }
 }

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -18,8 +18,7 @@ impl<'a> Shape for Points<'a> {
                     painter.paint(x, y, self.color);
                 }
             } else if let Some((x, y)) = painter.get_point(*x, *y) {
-                println!("false");
-                painter.paint(x, y, Color::Reset);
+                //painter.paint(x, y, Color::Reset);
             }
 
         }

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -12,7 +12,6 @@ pub struct Points<'a> {
 
 impl<'a> Shape for Points<'a> {
     fn draw(&self, painter: &mut Painter) {
-        println!("{:?}", self.coords);
         for (x, y, drawed) in self.coords {
             if *drawed {
                 if let Some((x, y)) = painter.get_point(*x, *y) {

--- a/src/widgets/canvas/points.rs
+++ b/src/widgets/canvas/points.rs
@@ -18,6 +18,7 @@ impl<'a> Shape for Points<'a> {
                     painter.paint(x, y, self.color);
                 }
             } else if let Some((x, y)) = painter.get_point(*x, *y) {
+                println!("false");
                 painter.paint(x, y, Color::Reset);
             }
 

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -559,7 +559,7 @@ impl<'a> Widget for Chart<'a> {
                     });
                     if let GraphType::Line = dataset.graph_type {
                         for data in dataset.data.windows(2) {
-                            if !data[0].2 {
+                            if !data[1].2 {
                                 continue;
                             } else {
                                 ctx.draw(&Line {

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -95,6 +95,8 @@ pub enum GraphType {
     Scatter,
     /// Draw each point and lines between each point using the same marker
     Line,
+    /// Draw each point and lines between each point using the same marker, with a boolean if the line is rendered
+    Svg,
 }
 
 /// A group of data points
@@ -103,7 +105,7 @@ pub struct Dataset<'a> {
     /// Name of the dataset (used in the legend if shown)
     name: Cow<'a, str>,
     /// A reference to the actual data
-    data: &'a [(f64, f64)],
+    data: &'a [(f64, f64, bool)],
     /// Symbol used for each points of this dataset
     marker: symbols::Marker,
     /// Determines graph type used for drawing points
@@ -133,7 +135,7 @@ impl<'a> Dataset<'a> {
         self
     }
 
-    pub fn data(mut self, data: &'a [(f64, f64)]) -> Dataset<'a> {
+    pub fn data(mut self, data: &'a [(f64, f64, bool)]) -> Dataset<'a> {
         self.data = data;
         self
     }
@@ -629,7 +631,7 @@ mod tests {
 
     #[test]
     fn it_should_hide_the_legend() {
-        let data = [(0.0, 5.0), (1.0, 6.0), (3.0, 7.0)];
+        let data = [(0.0, 5.0, true), (1.0, 6.0, true), (3.0, 7.0, true)];
         let cases = [
             LegendTestCase {
                 chart_area: Rect::new(0, 0, 100, 100),

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -559,13 +559,18 @@ impl<'a> Widget for Chart<'a> {
                     });
                     if let GraphType::Line = dataset.graph_type {
                         for data in dataset.data.windows(2) {
-                            ctx.draw(&Line {
-                                x1: data[0].0,
-                                y1: data[0].1,
-                                x2: data[1].0,
-                                y2: data[1].1,
-                                color: dataset.style.fg.unwrap_or(Color::Reset),
-                            })
+                            if !data[0].2 || !data[1].2 {
+                                continue;
+                            } else {
+                                ctx.draw(&Line {
+                                    x1: data[0].0,
+                                    y1: data[0].1,
+                                    x2: data[1].0,
+                                    y2: data[1].1,
+                                    color: dataset.style.fg.unwrap_or(Color::Reset),
+                                })
+                            }
+
                         }
                     }
                 })

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -559,7 +559,7 @@ impl<'a> Widget for Chart<'a> {
                     });
                     if let GraphType::Line = dataset.graph_type {
                         for data in dataset.data.windows(2) {
-                            if !data[0].2 || !data[1].2 {
+                            if !data[0].2 && !data[1].2 {
                                 continue;
                             } else {
                                 ctx.draw(&Line {

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -559,7 +559,7 @@ impl<'a> Widget for Chart<'a> {
                     });
                     if let GraphType::Line = dataset.graph_type {
                         for data in dataset.data.windows(2) {
-                            if !data[0].2 && !data[1].2 {
+                            if !data[0].2 {
                                 continue;
                             } else {
                                 ctx.draw(&Line {

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -40,7 +40,7 @@ fn widgets_chart_can_render_on_small_areas() {
                 let datasets = vec![Dataset::default()
                     .marker(symbols::Marker::Braille)
                     .style(Style::default().fg(Color::Magenta))
-                    .data(&[(0.0, 0.0)])];
+                    .data(&[(0.0, 0.0, true)])];
                 let chart = Chart::new(datasets)
                     .block(Block::default().title("Plot").borders(Borders::ALL))
                     .x_axis(
@@ -265,7 +265,7 @@ fn widgets_chart_can_have_axis_with_zero_length_bounds() {
             let datasets = vec![Dataset::default()
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(Color::Magenta))
-                .data(&[(0.0, 0.0)])];
+                .data(&[(0.0, 0.0, true)])];
             let chart = Chart::new(datasets)
                 .block(Block::default().title("Plot").borders(Borders::ALL))
                 .x_axis(
@@ -302,9 +302,9 @@ fn widgets_chart_handles_overflows() {
                 .marker(symbols::Marker::Braille)
                 .style(Style::default().fg(Color::Magenta))
                 .data(&[
-                    (1_588_298_471.0, 1.0),
-                    (1_588_298_473.0, 0.0),
-                    (1_588_298_496.0, 1.0),
+                    (1_588_298_471.0, 1.0, true),
+                    (1_588_298_473.0, 0.0, true),
+                    (1_588_298_496.0, 1.0, true),
                 ])];
             let chart = Chart::new(datasets)
                 .block(Block::default().title("Plot").borders(Borders::ALL))
@@ -379,34 +379,34 @@ fn widgets_chart_can_have_a_legend() {
                     .name("Dataset 1")
                     .style(Style::default().fg(Color::Blue))
                     .data(&[
-                        (0.0, 0.0),
-                        (10.0, 1.0),
-                        (20.0, 2.0),
-                        (30.0, 3.0),
-                        (40.0, 4.0),
-                        (50.0, 5.0),
-                        (60.0, 6.0),
-                        (70.0, 7.0),
-                        (80.0, 8.0),
-                        (90.0, 9.0),
-                        (100.0, 10.0),
+                        (0.0, 0.0, true),
+                        (10.0, 1.0, true),
+                        (20.0, 2.0, true),
+                        (30.0, 3.0, true),
+                        (40.0, 4.0, true),
+                        (50.0, 5.0, true),
+                        (60.0, 6.0, true),
+                        (70.0, 7.0, true),
+                        (80.0, 8.0, true),
+                        (90.0, 9.0, true),
+                        (100.0, 10.0, true),
                     ])
                     .graph_type(Line),
                 Dataset::default()
                     .name("Dataset 2")
                     .style(Style::default().fg(Color::Green))
                     .data(&[
-                        (0.0, 10.0),
-                        (10.0, 9.0),
-                        (20.0, 8.0),
-                        (30.0, 7.0),
-                        (40.0, 6.0),
-                        (50.0, 5.0),
-                        (60.0, 4.0),
-                        (70.0, 3.0),
-                        (80.0, 2.0),
-                        (90.0, 1.0),
-                        (100.0, 0.0),
+                        (0.0, 10.0, true),
+                        (10.0, 9.0, true),
+                        (20.0, 8.0, true),
+                        (30.0, 7.0, true),
+                        (40.0, 6.0, true),
+                        (50.0, 5.0, true),
+                        (60.0, 4.0, true),
+                        (70.0, 3.0, true),
+                        (80.0, 2.0, true),
+                        (90.0, 1.0, true),
+                        (100.0, 0.0, true),
                     ])
                     .graph_type(Line),
             ];


### PR DESCRIPTION
## Description
This pull requests adds the contents of all the other symbols originally in the symbols.rs file to the Markers enum.
<!--
A clear and concise description of what this PR changes.
-->

<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
-->
I don't know exactly how it can be tested, nor do I know how to write tests.
Circled use case for 'symbols::Blocks::FULL', (█)
![2023-04-04_17-00](https://user-images.githubusercontent.com/38308401/229713355-301250be-43e5-4cce-aca6-da54dd596211.png)
Use case for 'symbols::Lines::Cross', (┼)
![2023-04-04_17-06](https://user-images.githubusercontent.com/38308401/229714494-98928652-5db2-4706-a92e-179014e84968.png)



## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.

