### PR TITLE
Feature: Ability to mark terminal dirty and force a full repaint on next draw call

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -65,6 +65,11 @@ impl Cell {
         self.bg = Color::Reset;
         self.modifier = Modifier::empty();
     }
+    /// Marks cell dirty so it has to be redrawn
+    pub fn mark_dirty(&mut self) {
+        self.reset();
+        self.symbol.clear();
+    }
 }
 
 impl Default for Cell {
@@ -361,6 +366,12 @@ impl Buffer {
             self.content.resize(length, Default::default());
         }
         self.area = area;
+    }
+    /// Marks entire buffer dirty
+    pub fn mark_dirty(&mut self) {
+        for c in &mut self.content {
+            c.mark_dirty();
+        }
     }
 
     /// Reset all cells in the buffer

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -317,6 +317,12 @@ where
         Ok(())
     }
 
+    /// Mark the underlying buffer dirty, forcing a full redraw on the next draw call.
+    pub fn mark_dirty(&mut self) {
+        // Mark all cells in the back buffer dirty
+        self.buffers[1 - self.current].mark_dirty();
+    }
+
     /// Queries the real size of the backend.
     pub fn size(&self) -> io::Result<Rect> {
         self.backend.size()

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -1,9 +1,11 @@
 use std::error::Error;
+use tui::buffer::Cell;
+use tui::style::{Color, Modifier};
 use tui::{
     backend::{Backend, TestBackend},
     layout::Rect,
     widgets::Paragraph,
-    Terminal,
+    Frame, Terminal,
 };
 
 #[test]
@@ -32,5 +34,75 @@ fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
     })?;
     assert_eq!(frame.buffer.get(0, 0).symbol, "t");
     assert_eq!(frame.area, Rect::new(0, 0, 8, 8));
+    Ok(())
+}
+
+#[test]
+fn terminal_clear_wipes_terminal_and_does_full_redraw() -> Result<(), Box<dyn Error>> {
+    let backend = TestBackend::new(5, 5);
+    let mut terminal = Terminal::new(backend)?;
+    let draw_fun = |f: &mut Frame<TestBackend>| {
+        let paragrah = Paragraph::new("Tests\n".repeat(5));
+        f.render_widget(paragrah, f.size());
+    };
+    terminal.draw(draw_fun)?;
+    terminal.clear()?;
+    assert!(terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .find(|cell| cell.symbol.ne(" "))
+        .is_none());
+    terminal.draw(draw_fun)?;
+    assert_eq!(
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol.clone())
+            .collect::<Vec<_>>()
+            .join(""),
+        "Tests".repeat(5)
+    );
+    Ok(())
+}
+
+#[test]
+fn terminal_mark_dirty_does_full_redraw() -> Result<(), Box<dyn Error>> {
+    let backend = TestBackend::new(5, 5);
+    let mut terminal = Terminal::new(backend)?;
+    let draw_fun = |f: &mut Frame<TestBackend>| {
+        let paragrah = Paragraph::new("Tests\n".repeat(5));
+        f.render_widget(paragrah, f.size());
+    };
+    terminal.draw(draw_fun)?;
+    terminal.mark_dirty();
+    let mut fill_cell = Cell {
+        symbol: "#".to_string(),
+        fg: Color::Gray,
+        bg: Color::Gray,
+        modifier: Modifier::all(),
+    };
+    for row in 0..5 {
+        for col in 0..5 {
+            terminal
+                .backend_mut()
+                .draw(std::iter::once((row, col, &fill_cell)))?;
+        }
+    }
+    terminal.draw(draw_fun)?;
+    assert_eq!(
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol.clone())
+            .collect::<Vec<_>>()
+            .join(""),
+        "Tests".repeat(5)
+    );
     Ok(())
 }


### PR DESCRIPTION
## Description
Adds some new functions to `Cell`, `Buffer`, and `Terminal` that when called marks a given object dirty, meaning their current state on the terminal is unknown, so they should be repainted the next time `draw()` is called.

Uses a given cell's `.symbol` being empty as a "dirty" marker. Not sure how proper this is for an implementation, but it seems to work well.

## Testing guidelines
I've added some tests to `tests/terminal.rs`

## Checklist

* [x] I have read the contributing guidelines.
* [x] I have added relevant tests.
* [x] I have documented all new additions. I think.
